### PR TITLE
Security: Deployments fail-closed + auth defaults + secure_compare

### DIFF
--- a/app/controllers/rails_pulse/application_controller.rb
+++ b/app/controllers/rails_pulse/application_controller.rb
@@ -119,7 +119,8 @@ module RailsPulse
           logger.error "RailsPulse: No authentication method configured and RAILS_PULSE_PASSWORD not set. Access denied."
           false
         else
-          username == expected_username && password == expected_password
+          ActiveSupport::SecurityUtils.secure_compare(username.to_s, expected_username) &&
+            ActiveSupport::SecurityUtils.secure_compare(password.to_s, expected_password)
         end
       end
     end

--- a/app/controllers/rails_pulse/deployments_controller.rb
+++ b/app/controllers/rails_pulse/deployments_controller.rb
@@ -1,6 +1,7 @@
 module RailsPulse
   class DeploymentsController < ApplicationController
     skip_before_action :authenticate_rails_pulse_user!
+    skip_before_action :verify_authenticity_token, only: %i[create finish]
     before_action :authenticate_deployment_request!
 
     def create
@@ -44,10 +45,16 @@ module RailsPulse
     def authenticate_deployment_request!
       token = RailsPulse.configuration.deployment_api_token
       if token.present?
-        provided = request.headers["X-Rails-Pulse-Token"]
-        render json: { error: "Unauthorized" }, status: :unauthorized unless provided == token
-      else
+        provided = request.headers["X-Rails-Pulse-Token"].to_s
+        unless ActiveSupport::SecurityUtils.secure_compare(provided, token)
+          render json: { error: "Unauthorized" }, status: :unauthorized
+        end
+      elsif RailsPulse.configuration.authentication_enabled
         authenticate_rails_pulse_user!
+      else
+        # No token configured and authentication disabled — fail closed.
+        # Without a token there is no way to verify the caller.
+        render json: { error: "Unauthorized — set deployment_api_token or enable authentication" }, status: :unauthorized
       end
     end
 

--- a/lib/generators/rails_pulse/templates/rails_pulse.rb
+++ b/lib/generators/rails_pulse/templates/rails_pulse.rb
@@ -257,7 +257,8 @@ RailsPulse.configure do |config|
   # Example 4: Basic HTTP authentication
   # config.authentication_method = proc {
   #   authenticate_or_request_with_http_basic do |username, password|
-  #     username == ENV['RAILS_PULSE_USERNAME'] && password == ENV['RAILS_PULSE_PASSWORD']
+  #     ActiveSupport::SecurityUtils.secure_compare(username, ENV['RAILS_PULSE_USERNAME']) &&
+  #       ActiveSupport::SecurityUtils.secure_compare(password, ENV['RAILS_PULSE_PASSWORD'])
   #   end
   # }
 

--- a/lib/rails_pulse/configuration.rb
+++ b/lib/rails_pulse/configuration.rb
@@ -84,7 +84,7 @@ module RailsPulse
         rails_pulse_exception_groups: 10_000
       }
       @connects_to = nil
-      @authentication_enabled = Rails.env.production?
+      @authentication_enabled = !(Rails.env.development? || Rails.env.test?)
       @authentication_enabled_explicitly_set = false
       @authentication_method = nil
       @authentication_redirect_path = "/"

--- a/test/controllers/rails_pulse/deployments_controller_test.rb
+++ b/test/controllers/rails_pulse/deployments_controller_test.rb
@@ -3,9 +3,28 @@ require "test_helper"
 class RailsPulse::DeploymentsControllerTest < ActionDispatch::IntegrationTest
   fixtures :rails_pulse_deployments
 
+  DEPLOY_TOKEN = "test-deploy-token"
+
   def setup
     ENV["TEST_TYPE"] = "functional"
+    @original_token = RailsPulse.configuration.deployment_api_token
+    RailsPulse.configuration.deployment_api_token = DEPLOY_TOKEN
     super
+  end
+
+  def teardown
+    RailsPulse.configuration.deployment_api_token = @original_token
+    super
+  end
+
+  # Inject the deployment token into every request so the fail-closed
+  # guard doesn't reject them. Tests that exercise auth explicitly
+  # override the token or headers as needed.
+  %i[post put].each do |verb|
+    define_method(verb) do |path, **opts|
+      opts[:headers] = (opts[:headers] || {}).reverse_merge("X-Rails-Pulse-Token" => DEPLOY_TOKEN)
+      super(path, **opts)
+    end
   end
 
   # POST /deployments
@@ -137,7 +156,7 @@ class RailsPulse::DeploymentsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :created
   ensure
-    RailsPulse.configuration.deployment_api_token = nil
+    RailsPulse.configuration.deployment_api_token = DEPLOY_TOKEN
   end
 
   test "create returns 401 with wrong token" do
@@ -150,7 +169,7 @@ class RailsPulse::DeploymentsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :unauthorized
   ensure
-    RailsPulse.configuration.deployment_api_token = nil
+    RailsPulse.configuration.deployment_api_token = DEPLOY_TOKEN
   end
 
   test "create returns 401 when token configured but none provided" do
@@ -158,22 +177,25 @@ class RailsPulse::DeploymentsControllerTest < ActionDispatch::IntegrationTest
 
     post rails_pulse.deployments_path,
          params: { deployment: { revision: "tokensha3" } },
+         headers: { "X-Rails-Pulse-Token" => "" },
          as: :json
 
     assert_response :unauthorized
   ensure
-    RailsPulse.configuration.deployment_api_token = nil
+    RailsPulse.configuration.deployment_api_token = DEPLOY_TOKEN
   end
 
-  test "create falls through to UI auth when no token configured" do
-    assert_nil RailsPulse.configuration.deployment_api_token
+  test "create returns 401 when no token configured and auth disabled" do
+    RailsPulse.configuration.deployment_api_token = nil
 
-    # With authentication disabled (test default), the request should succeed
+    # Fail closed: no token configured means no way to verify the caller,
+    # even when dashboard auth is disabled.
     post rails_pulse.deployments_path,
          params: { deployment: { revision: "tokensha4" } },
+         headers: {},
          as: :json
 
-    assert_response :created
+    assert_response :unauthorized
   end
 
   # PUT /deployments/finish
@@ -282,7 +304,7 @@ class RailsPulse::DeploymentsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :unauthorized
   ensure
-    RailsPulse.configuration.deployment_api_token = nil
+    RailsPulse.configuration.deployment_api_token = DEPLOY_TOKEN
   end
 
   test "finish succeeds with correct token" do
@@ -295,6 +317,6 @@ class RailsPulse::DeploymentsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :ok
   ensure
-    RailsPulse.configuration.deployment_api_token = nil
+    RailsPulse.configuration.deployment_api_token = DEPLOY_TOKEN
   end
 end


### PR DESCRIPTION
## Summary

Addresses audit findings §7, §19, §20 from the 0.4.0 pre-release audit.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Changes Made

### §7 — Deployments endpoint fails open to anonymous writes
- When no deployment_api_token is configured AND authentication is disabled, the endpoint now returns 401 instead of silently allowing writes
- Added `skip_before_action :verify_authenticity_token` for create/finish actions so CI curl requests work in production

### §19 — Dashboard unauthenticated by default outside production
- Changed `authentication_enabled` default from `Rails.env.production?` to `!(Rails.env.development? || Rails.env.test?)`
- staging, qa, demo, and preview environments now require authentication by default

### §20 — Timing attack + CSRF
- Replaced `==` with `ActiveSupport::SecurityUtils.secure_compare` in deployment token check and HTTP Basic auth fallback
- Fixed template auth example to use secure_compare
- Added CSRF skip for the API-only deployments endpoint

## Breaking Changes

- [x] Breaking changes documented below

- Authentication is now enabled by default for all environments except development and test. Users on staging/qa/demo who relied on open access will need to configure authentication or explicitly set `config.authentication_enabled = false`.
- The deployments endpoint now requires a deployment_api_token when authentication is disabled.