### PR TITLE
Persist findings, and detect regressions rather than only thresholds

### DIFF
--- a/app/jobs/rails_pulse/finding_detection_job.rb
+++ b/app/jobs/rails_pulse/finding_detection_job.rb
@@ -1,0 +1,29 @@
+module RailsPulse
+  class FindingDetectionJob < ApplicationJob
+    # Runs the deterministic regression rules and records what they find.
+    #
+    # Scheduled once a day rather than hourly: baselines are built from day
+    # summaries, which SummaryJob writes at midnight for the day that just
+    # ended, so there is nothing new to compare against until the next one
+    # lands. SummaryJob invokes this after its daily rollup.
+    #
+    # @param as_of [Time, nil] treat this as "now" (defaults to the current time)
+    # @return [nil]
+    def perform(as_of = nil)
+      as_of ||= Time.current
+
+      result = FindingDetector.call(as_of: as_of)
+
+      RailsPulse.logger.info(
+        "Finding detection complete: #{result.detected} detected, " \
+        "#{result.opened} opened, #{result.reopened} reopened, #{result.resolved} resolved"
+      )
+
+      nil
+    rescue StandardError => e
+      RailsPulse.logger.error "Finding detection failed: #{e.message}"
+      RailsPulse.logger.error e.backtrace.join("\n")
+      raise
+    end
+  end
+end

--- a/app/jobs/rails_pulse/summary_job.rb
+++ b/app/jobs/rails_pulse/summary_job.rb
@@ -13,6 +13,10 @@ module RailsPulse
       if midnight?(target_hour)
         process_daily_summary(target_hour.to_date - 1.day)
 
+        # Regression detection compares complete days, so it has nothing new to
+        # say until the day summary it reads has been written.
+        detect_findings(target_hour)
+
         # Check if we should run weekly summary (Monday at midnight)
         process_weekly_summary((target_hour.to_date - 1.week).beginning_of_week) if monday?(target_hour)
 
@@ -36,6 +40,15 @@ module RailsPulse
 
     def first_of_month?(time)
       time.day == 1
+    end
+
+    # Detection failing must not take the summary job down with it: summaries
+    # are the data everything else depends on, findings are derived from them.
+    def detect_findings(as_of)
+      RailsPulse.logger.info "Detecting findings as of #{as_of}"
+      FindingDetectionJob.perform_now(as_of)
+    rescue StandardError => e
+      RailsPulse.logger.error "Finding detection failed, summaries unaffected: #{e.message}"
     end
 
     def process_hourly_summary(hour)

--- a/app/models/rails_pulse/dashboard/needs_attention.rb
+++ b/app/models/rails_pulse/dashboard/needs_attention.rb
@@ -16,7 +16,7 @@ module RailsPulse
       MAX_ITEMS = 10
 
       def to_attention_data
-        items    = route_items + query_items + job_items
+        items    = regression_items + route_items + query_items + job_items
         critical = items.select { |i| i[:severity] == :critical }.sort_by { |i| -i[:sort_score] }
         warning  = items.select { |i| i[:severity] == :warning  }.sort_by { |i| -i[:sort_score] }
 
@@ -36,6 +36,60 @@ module RailsPulse
       end
 
       private
+
+      # Persisted regressions, from FindingDetector. These answer "what got
+      # worse?" where every other rule in this class answers "what is slow?" —
+      # a route that tripled from 90ms to 280ms is invisible to a threshold and
+      # is exactly what a user wants to see first.
+      #
+      # Findings are sorted above threshold items of the same severity by
+      # scoring on the size of the change, which is unbounded, rather than on a
+      # duration.
+      def regression_items
+        return [] unless findings_available?
+
+        RailsPulse::Finding.unresolved.recent.limit(MAX_ITEMS).map do |finding|
+          {
+            type:       "REGRESSION",
+            name:       finding.subject_label,
+            reason:     regression_reason(finding),
+            metric:     "#{finding.percent_change.round(0).to_i}% worse",
+            metric_sub: finding.to_s,
+            link:       regression_link(finding),
+            severity:   finding.severity.to_sym,
+            sort_score: (finding.ratio.to_f * 1000),
+            monospace:  finding.subject_type == "RailsPulse::Query"
+          }
+        end
+      end
+
+      def regression_reason(finding)
+        metric_label = finding.metric == "error_rate" ? "Error rate" : finding.metric.upcase
+
+        if finding.change_point_known?
+          precision = finding.hourly_change_point? ? finding.changed_at.strftime("%b %-d %H:%M") : finding.changed_at.strftime("%b %-d")
+          "#{metric_label} regression · started around #{precision}"
+        else
+          "#{metric_label} regression vs its own baseline"
+        end
+      end
+
+      def regression_link(finding)
+        case finding.subject_type
+        when "RailsPulse::Route" then url_helpers.route_path(finding.subject_id)
+        when "RailsPulse::Query" then url_helpers.query_path(finding.subject_id)
+        when "RailsPulse::Job"   then url_helpers.job_path(finding.subject_id)
+        else url_helpers.root_path
+        end
+      end
+
+      # The findings table arrives in a migration, so a host that has upgraded
+      # the gem but not yet run migrations must still get a working dashboard.
+      def findings_available?
+        RailsPulse::Finding.table_exists?
+      rescue ActiveRecord::ActiveRecordError
+        false
+      end
 
       def storage_pressure_items
         StoragePressure.new.pressure_items

--- a/app/models/rails_pulse/finding.rb
+++ b/app/models/rails_pulse/finding.rb
@@ -1,0 +1,105 @@
+module RailsPulse
+  class Finding < RailsPulse::ApplicationRecord
+    self.table_name = "rails_pulse_findings"
+
+    KINDS = %w[performance_regression error_rate_regression].freeze
+    SEVERITIES = %w[warning critical].freeze
+    STATUSES = %w[open acknowledged resolved].freeze
+
+    validates :fingerprint, presence: true, uniqueness: true
+    validates :kind,     inclusion: { in: KINDS }
+    validates :severity, inclusion: { in: SEVERITIES }
+    validates :status,   inclusion: { in: STATUSES }
+    validates :subject_type, :subject_id, :metric, presence: true
+    validates :first_detected_at, :last_detected_at, presence: true
+
+    scope :open,         -> { where(status: "open") }
+    scope :acknowledged, -> { where(status: "acknowledged") }
+    scope :resolved,     -> { where(status: "resolved") }
+    scope :unresolved,   -> { where(status: %w[open acknowledged]) }
+    scope :critical,     -> { where(severity: "critical") }
+    scope :recent,       -> { order(last_detected_at: :desc) }
+
+    # Identity is the thing being reported, not the run that reported it: the
+    # same route regressing on the same metric is one finding that keeps being
+    # seen, not a new row every detection run. This mirrors how ExceptionGroup
+    # fingerprints a raise site rather than a raise.
+    def self.fingerprint_for(kind:, subject_type:, subject_id:, metric:)
+      Digest::SHA256.hexdigest("#{kind}:#{subject_type}:#{subject_id}:#{metric}")
+    end
+
+    def self.ransackable_attributes(auth_object = nil)
+      %w[
+        id kind metric severity status subject_type subject_id
+        baseline_value current_value delta ratio
+        first_detected_at last_detected_at resolved_at detection_count changed_at
+      ]
+    end
+
+    def self.ransackable_associations(auth_object = nil)
+      []
+    end
+
+    # The record this finding is about. Nil for the overall request rollup,
+    # which has no row of its own, and nil if the subject has since been cleaned
+    # up — callers must handle both.
+    def subject
+      return nil if overall_requests?
+
+      @subject ||= subject_type.constantize.find_by(id: subject_id)
+    end
+
+    def overall_requests?
+      subject_type == "RailsPulse::Request" && subject_id.to_i.zero?
+    end
+
+    def subject_label
+      return "All requests" if overall_requests?
+
+      record = subject
+      return "#{subject_type.demodulize} ##{subject_id}" if record.nil?
+
+      case subject_type
+      when "RailsPulse::Route" then record.path
+      when "RailsPulse::Query" then record.normalized_sql
+      when "RailsPulse::Job"   then record.name
+      end.presence || "#{subject_type.demodulize} ##{subject_id}"
+    end
+
+    def unit
+      metric == "error_rate" ? "%" : "ms"
+    end
+
+    def percent_change
+      return nil if ratio.nil?
+
+      (ratio - 1) * 100
+    end
+
+    def resolved?
+      status == "resolved"
+    end
+
+    # A change point is only meaningful if one could be located, and its
+    # precision depends on whether hourly summaries still covered the window.
+    def change_point_known?
+      changed_at.present?
+    end
+
+    def hourly_change_point?
+      change_point_granularity == "hour"
+    end
+
+    def to_s
+      "#{subject_label}: #{format_value(baseline_value)} → #{format_value(current_value)}"
+    end
+
+    private
+
+    def format_value(value)
+      return "—" if value.nil?
+
+      metric == "error_rate" ? "#{value.round(2)}%" : "#{value.round(0).to_i}ms"
+    end
+  end
+end

--- a/app/services/rails_pulse/finding_detector.rb
+++ b/app/services/rails_pulse/finding_detector.rb
@@ -1,0 +1,153 @@
+module RailsPulse
+  # Turns comparisons into persisted findings.
+  #
+  # The dashboard's existing rules classify against absolute thresholds — a
+  # route is reported because it is slow, not because it got slower — and they
+  # run at render time, so nothing they conclude survives the response. This
+  # runs the deterministic regression rules over every subject and writes what
+  # it finds, so a finding can be trended, acknowledged, and read back later by
+  # something other than the page that computed it.
+  #
+  # Lifecycle mirrors ExceptionGroup: identity is the thing being reported, so
+  # a route that keeps regressing is one finding that keeps being seen. A
+  # finding that stops being detected resolves itself; if it comes back, it
+  # reopens rather than starting a second row.
+  class FindingDetector
+    METRICS = {
+      p95:        "performance_regression",
+      error_rate: "error_rate_regression"
+    }.freeze
+
+    Result = Struct.new(:detected, :opened, :reopened, :resolved, keyword_init: true)
+
+    def self.call(as_of: Time.current)
+      new(as_of: as_of).call
+    end
+
+    def initialize(as_of: Time.current)
+      @as_of  = as_of
+      @result = Result.new(detected: 0, opened: 0, reopened: 0, resolved: 0)
+    end
+
+    def call
+      seen = []
+
+      subject_scopes.each do |scope|
+        METRICS.each do |metric, kind|
+          Operations::Compare.scan(scope, metric: metric, as_of: as_of).each do |comparison|
+            next unless comparison.regression?
+
+            seen << record(comparison, kind: kind)
+            @result.detected += 1
+          end
+        end
+      end
+
+      resolve_findings_absent_from(seen)
+      @result
+    end
+
+    private
+
+    attr_reader :as_of
+
+    # Only scan what the host is actually tracking. Scanning jobs when job
+    # tracking is off would produce findings for a table that stopped being
+    # written to, which reads as a regression that nobody can act on.
+    def subject_scopes
+      scopes = [ RailsPulse::Route.all, RailsPulse::Query.all ]
+      scopes << RailsPulse::Job.all if RailsPulse.configuration.track_jobs
+      scopes
+    end
+
+    def record(comparison, kind:)
+      subject = comparison.subject
+
+      fingerprint = Finding.fingerprint_for(
+        kind:         kind,
+        subject_type: subject.type,
+        subject_id:   subject.id,
+        metric:       comparison.metric
+      )
+
+      finding = Finding.find_or_initialize_by(fingerprint: fingerprint)
+
+      if finding.new_record?
+        finding.first_detected_at = as_of
+        finding.detection_count   = 0
+        @result.opened += 1
+      elsif finding.resolved?
+        # It came back. Reopen rather than opening a second row, so the history
+        # of how often this subject regresses stays on one record.
+        finding.resolved_at = nil
+        finding.status      = "open"
+        @result.reopened += 1
+      end
+
+      change_point = locate_change_point(subject, comparison.metric)
+
+      finding.assign_attributes(
+        kind:             kind,
+        subject_type:     subject.type,
+        subject_id:       subject.id,
+        metric:           comparison.metric.to_s,
+        severity:         severity_for(comparison),
+        baseline_value:   comparison.baseline_value,
+        current_value:    comparison.current_value,
+        delta:            comparison.delta,
+        ratio:            comparison.ratio,
+        baseline_count:   comparison.baseline_count,
+        current_count:    comparison.current_count,
+        changed_at:       change_point&.at,
+        change_point_granularity: change_point&.granularity,
+        last_detected_at: as_of,
+        detection_count:  finding.detection_count.to_i + 1
+      )
+
+      finding.save!
+      finding.fingerprint
+    end
+
+    # A regression is critical when the metric has not just moved but landed
+    # somewhere the host already considers critical. That reuses the thresholds
+    # the user has already tuned rather than inventing a second severity scale
+    # they would have to learn.
+    def severity_for(comparison)
+      return "critical" if comparison.metric == :error_rate &&
+        comparison.current_value >= Dashboard::Concerns::ThresholdConstants::CRITICAL_ERROR_RATE
+
+      threshold = critical_threshold_for(comparison.subject.type)
+      return "critical" if threshold && comparison.current_value >= threshold
+
+      "warning"
+    end
+
+    def critical_threshold_for(subject_type)
+      config = RailsPulse.configuration
+
+      case subject_type
+      when "RailsPulse::Route"   then config.route_thresholds[:critical]
+      when "RailsPulse::Query"   then config.query_thresholds[:critical]
+      when "RailsPulse::Job"     then config.job_thresholds[:critical]
+      when "RailsPulse::Request" then config.request_thresholds[:critical]
+      end
+    end
+
+    def locate_change_point(subject, metric)
+      Operations::ChangePoint.call(subject, metric: metric)
+    end
+
+    # Anything still open that this run did not detect has stopped regressing.
+    # Resolving is what keeps the findings list a description of the present
+    # rather than an append-only log of everything that ever went wrong.
+    def resolve_findings_absent_from(seen_fingerprints)
+      stale = Finding.unresolved
+      stale = stale.where.not(fingerprint: seen_fingerprints) if seen_fingerprints.any?
+
+      @result.resolved = stale.count
+      stale.find_each do |finding|
+        finding.update!(status: "resolved", resolved_at: as_of)
+      end
+    end
+  end
+end

--- a/db/rails_pulse_migrate/20260901000001_create_rails_pulse_findings.rb
+++ b/db/rails_pulse_migrate/20260901000001_create_rails_pulse_findings.rb
@@ -1,0 +1,44 @@
+class CreateRailsPulseFindings < ActiveRecord::Migration[7.0]
+  def change
+    unless table_exists?(:rails_pulse_findings)
+      create_table :rails_pulse_findings do |t|
+        t.string   :fingerprint,  null: false, comment: "SHA256 of kind + subject + metric — stable identity across detection runs"
+        t.string   :kind,         null: false, comment: "What was detected, e.g. performance_regression"
+        t.string   :subject_type, null: false, comment: "RailsPulse::Route, RailsPulse::Query, RailsPulse::Job or RailsPulse::Request"
+        t.bigint   :subject_id,   null: false, comment: "Id of the subject; 0 for the overall request rollup"
+        t.string   :metric,       null: false, comment: "p50, p95, p99, avg or error_rate"
+        t.string   :severity,     null: false, comment: "warning or critical"
+        t.string   :status,       null: false, default: "open", comment: "open, acknowledged or resolved"
+        t.float    :baseline_value, comment: "Traffic-weighted metric across the baseline window"
+        t.float    :current_value,  comment: "Metric across the window under test"
+        t.float    :delta,          comment: "current_value - baseline_value"
+        t.float    :ratio,          comment: "current_value / baseline_value"
+        t.integer  :baseline_count, comment: "Observations behind the baseline"
+        t.integer  :current_count,  comment: "Observations behind the current window"
+        t.datetime :changed_at,     comment: "Estimated change point, when one could be located"
+        t.string   :change_point_granularity, comment: "hour or day — the precision of changed_at"
+        t.datetime :first_detected_at, null: false, comment: "When this finding was first raised"
+        t.datetime :last_detected_at,  null: false, comment: "Most recent detection run that still saw it"
+        t.datetime :resolved_at,       comment: "When the finding last stopped being detected"
+        t.integer  :detection_count,   null: false, default: 0, comment: "Number of runs that have seen this finding"
+        t.timestamps
+      end
+    end
+
+    unless index_exists?(:rails_pulse_findings, :fingerprint, name: "index_rails_pulse_findings_on_fingerprint")
+      add_index :rails_pulse_findings, :fingerprint, unique: true, name: "index_rails_pulse_findings_on_fingerprint"
+    end
+
+    unless index_exists?(:rails_pulse_findings, :status, name: "index_rails_pulse_findings_on_status")
+      add_index :rails_pulse_findings, :status, name: "index_rails_pulse_findings_on_status"
+    end
+
+    unless index_exists?(:rails_pulse_findings, :last_detected_at, name: "index_rails_pulse_findings_on_last_detected_at")
+      add_index :rails_pulse_findings, :last_detected_at, name: "index_rails_pulse_findings_on_last_detected_at"
+    end
+
+    unless index_exists?(:rails_pulse_findings, [ :subject_type, :subject_id ], name: "index_rails_pulse_findings_on_subject")
+      add_index :rails_pulse_findings, [ :subject_type, :subject_id ], name: "index_rails_pulse_findings_on_subject"
+    end
+  end
+end

--- a/db/rails_pulse_schema.rb
+++ b/db/rails_pulse_schema.rb
@@ -7,7 +7,7 @@ require "rails_pulse/route_indexes" unless defined?(RailsPulse::RouteIndexes)
 RailsPulse::Schema = lambda do |connection|
   adapter = connection.adapter_name.downcase
   # Skip if all tables already exist to prevent conflicts
-  required_tables = [ :rails_pulse_routes, :rails_pulse_queries, :rails_pulse_requests, :rails_pulse_operations, :rails_pulse_jobs, :rails_pulse_job_runs, :rails_pulse_summaries, :rails_pulse_deployments, :rails_pulse_exception_groups, :rails_pulse_exception_occurrences ]
+  required_tables = [ :rails_pulse_routes, :rails_pulse_queries, :rails_pulse_requests, :rails_pulse_operations, :rails_pulse_jobs, :rails_pulse_job_runs, :rails_pulse_summaries, :rails_pulse_deployments, :rails_pulse_exception_groups, :rails_pulse_exception_occurrences, :rails_pulse_findings ]
 
   # Check which tables already exist
   existing_tables = required_tables.select { |table| connection.table_exists?(table) }
@@ -257,6 +257,36 @@ RailsPulse::Schema = lambda do |connection|
 
     connection.add_index :rails_pulse_exception_occurrences, :occurred_at,        name: "index_rp_exception_occurrences_on_occurred_at"
     connection.add_index :rails_pulse_exception_occurrences, :exception_group_id, name: "index_rp_exception_occurrences_on_group_id"
+  end
+
+  unless connection.table_exists?(:rails_pulse_findings)
+    connection.create_table :rails_pulse_findings do |t|
+      t.string   :fingerprint,  null: false, comment: "SHA256 of kind + subject + metric — stable identity across detection runs"
+      t.string   :kind,         null: false, comment: "What was detected, e.g. performance_regression"
+      t.string   :subject_type, null: false, comment: "RailsPulse::Route, RailsPulse::Query, RailsPulse::Job or RailsPulse::Request"
+      t.bigint   :subject_id,   null: false, comment: "Id of the subject; 0 for the overall request rollup"
+      t.string   :metric,       null: false, comment: "p50, p95, p99, avg or error_rate"
+      t.string   :severity,     null: false, comment: "warning or critical"
+      t.string   :status,       null: false, default: "open", comment: "open, acknowledged or resolved"
+      t.float    :baseline_value, comment: "Traffic-weighted metric across the baseline window"
+      t.float    :current_value,  comment: "Metric across the window under test"
+      t.float    :delta,          comment: "current_value - baseline_value"
+      t.float    :ratio,          comment: "current_value / baseline_value"
+      t.integer  :baseline_count, comment: "Observations behind the baseline"
+      t.integer  :current_count,  comment: "Observations behind the current window"
+      t.datetime :changed_at,     comment: "Estimated change point, when one could be located"
+      t.string   :change_point_granularity, comment: "hour or day — the precision of changed_at"
+      t.datetime :first_detected_at, null: false, comment: "When this finding was first raised"
+      t.datetime :last_detected_at,  null: false, comment: "Most recent detection run that still saw it"
+      t.datetime :resolved_at,       comment: "When the finding last stopped being detected"
+      t.integer  :detection_count,   null: false, default: 0, comment: "Number of runs that have seen this finding"
+      t.timestamps
+    end
+
+    connection.add_index :rails_pulse_findings, :fingerprint, unique: true, name: "index_rails_pulse_findings_on_fingerprint"
+    connection.add_index :rails_pulse_findings, :status,                    name: "index_rails_pulse_findings_on_status"
+    connection.add_index :rails_pulse_findings, :last_detected_at,          name: "index_rails_pulse_findings_on_last_detected_at"
+    connection.add_index :rails_pulse_findings, [ :subject_type, :subject_id ], name: "index_rails_pulse_findings_on_subject"
   end
 
   # Add indexes to existing tables for efficient aggregation

--- a/lib/generators/rails_pulse/base_methods.rb
+++ b/lib/generators/rails_pulse/base_methods.rb
@@ -15,6 +15,7 @@ module RailsPulse
         rails_pulse_deployments
         rails_pulse_exception_groups
         rails_pulse_exception_occurrences
+        rails_pulse_findings
       ].freeze
 
       # Generate next migration number for timestamped migrations

--- a/lib/generators/rails_pulse/templates/db/rails_pulse_schema.rb
+++ b/lib/generators/rails_pulse/templates/db/rails_pulse_schema.rb
@@ -7,7 +7,7 @@ require "rails_pulse/route_indexes" unless defined?(RailsPulse::RouteIndexes)
 RailsPulse::Schema = lambda do |connection|
   adapter = connection.adapter_name.downcase
   # Skip if all tables already exist to prevent conflicts
-  required_tables = [ :rails_pulse_routes, :rails_pulse_queries, :rails_pulse_requests, :rails_pulse_operations, :rails_pulse_jobs, :rails_pulse_job_runs, :rails_pulse_summaries, :rails_pulse_deployments, :rails_pulse_exception_groups, :rails_pulse_exception_occurrences ]
+  required_tables = [ :rails_pulse_routes, :rails_pulse_queries, :rails_pulse_requests, :rails_pulse_operations, :rails_pulse_jobs, :rails_pulse_job_runs, :rails_pulse_summaries, :rails_pulse_deployments, :rails_pulse_exception_groups, :rails_pulse_exception_occurrences, :rails_pulse_findings ]
 
   # Check which tables already exist
   existing_tables = required_tables.select { |table| connection.table_exists?(table) }
@@ -257,6 +257,36 @@ RailsPulse::Schema = lambda do |connection|
 
     connection.add_index :rails_pulse_exception_occurrences, :occurred_at,        name: "index_rp_exception_occurrences_on_occurred_at"
     connection.add_index :rails_pulse_exception_occurrences, :exception_group_id, name: "index_rp_exception_occurrences_on_group_id"
+  end
+
+  unless connection.table_exists?(:rails_pulse_findings)
+    connection.create_table :rails_pulse_findings do |t|
+      t.string   :fingerprint,  null: false, comment: "SHA256 of kind + subject + metric — stable identity across detection runs"
+      t.string   :kind,         null: false, comment: "What was detected, e.g. performance_regression"
+      t.string   :subject_type, null: false, comment: "RailsPulse::Route, RailsPulse::Query, RailsPulse::Job or RailsPulse::Request"
+      t.bigint   :subject_id,   null: false, comment: "Id of the subject; 0 for the overall request rollup"
+      t.string   :metric,       null: false, comment: "p50, p95, p99, avg or error_rate"
+      t.string   :severity,     null: false, comment: "warning or critical"
+      t.string   :status,       null: false, default: "open", comment: "open, acknowledged or resolved"
+      t.float    :baseline_value, comment: "Traffic-weighted metric across the baseline window"
+      t.float    :current_value,  comment: "Metric across the window under test"
+      t.float    :delta,          comment: "current_value - baseline_value"
+      t.float    :ratio,          comment: "current_value / baseline_value"
+      t.integer  :baseline_count, comment: "Observations behind the baseline"
+      t.integer  :current_count,  comment: "Observations behind the current window"
+      t.datetime :changed_at,     comment: "Estimated change point, when one could be located"
+      t.string   :change_point_granularity, comment: "hour or day — the precision of changed_at"
+      t.datetime :first_detected_at, null: false, comment: "When this finding was first raised"
+      t.datetime :last_detected_at,  null: false, comment: "Most recent detection run that still saw it"
+      t.datetime :resolved_at,       comment: "When the finding last stopped being detected"
+      t.integer  :detection_count,   null: false, default: 0, comment: "Number of runs that have seen this finding"
+      t.timestamps
+    end
+
+    connection.add_index :rails_pulse_findings, :fingerprint, unique: true, name: "index_rails_pulse_findings_on_fingerprint"
+    connection.add_index :rails_pulse_findings, :status,                    name: "index_rails_pulse_findings_on_status"
+    connection.add_index :rails_pulse_findings, :last_detected_at,          name: "index_rails_pulse_findings_on_last_detected_at"
+    connection.add_index :rails_pulse_findings, [ :subject_type, :subject_id ], name: "index_rails_pulse_findings_on_subject"
   end
 
   # Add indexes to existing tables for efficient aggregation

--- a/lib/generators/rails_pulse/templates/rails_pulse.rb
+++ b/lib/generators/rails_pulse/templates/rails_pulse.rb
@@ -337,7 +337,8 @@ RailsPulse.configure do |config|
     rails_pulse_job_runs: 50_000,                 # Individual job executions (high volume)
     rails_pulse_jobs: 1_000,                      # Unique job classes (low volume)
     rails_pulse_exception_occurrences: 50_000,    # Individual exception raises (high volume)
-    rails_pulse_exception_groups: 10_000          # Distinct exception sites (moderate volume)
+    rails_pulse_exception_groups: 10_000,         # Distinct exception sites (moderate volume)
+    rails_pulse_findings: 1_000                   # Detected regressions (low volume)
   }
 
   # ====================================================================================================

--- a/lib/rails_pulse/cleanup_service.rb
+++ b/lib/rails_pulse/cleanup_service.rb
@@ -78,6 +78,25 @@ module RailsPulse
         @stats[:count_based][:exception_groups]      = cleanup_exception_groups_by_count
         @stats[:count_based][:orphaned_exception_groups] = cleanup_orphaned_exception_groups
       end
+      @stats[:count_based][:findings] = cleanup_findings_by_count if findings_table_exists?
+    end
+
+    # Only resolved findings are prunable. An unresolved one is a live statement
+    # about the application's current behaviour and stays until detection says
+    # otherwise, however old it is.
+    def cleanup_findings_by_count
+      cleanup_by_count(
+        RailsPulse::Finding,
+        :rails_pulse_findings,
+        order_column: :last_detected_at,
+        scope: RailsPulse::Finding.resolved
+      )
+    end
+
+    def findings_table_exists?
+      RailsPulse::Finding.table_exists?
+    rescue ActiveRecord::ActiveRecordError
+      false
     end
 
     # Shared helper: delete oldest records beyond a configured max count

--- a/lib/rails_pulse/configuration.rb
+++ b/lib/rails_pulse/configuration.rb
@@ -85,7 +85,8 @@ module RailsPulse
         rails_pulse_routes: 1_000,
         rails_pulse_jobs: 1_000,
         rails_pulse_exception_occurrences: 50_000,
-        rails_pulse_exception_groups: 10_000
+        rails_pulse_exception_groups: 10_000,
+        rails_pulse_findings: 1_000
       }
       @connects_to = nil
       @authentication_enabled = !(Rails.env.development? || Rails.env.test?)

--- a/lib/rails_pulse/engine.rb
+++ b/lib/rails_pulse/engine.rb
@@ -20,6 +20,7 @@ module RailsPulse
   autoload :TagFilterService, File.expand_path("../../app/services/rails_pulse/tag_filter_service", __dir__)
   autoload :ExceptionCaptureService, File.expand_path("../../app/services/rails_pulse/exception_capture_service", __dir__)
   autoload :ExceptionMessageSanitizer, File.expand_path("../../app/services/rails_pulse/exception_message_sanitizer", __dir__)
+  autoload :FindingDetector, File.expand_path("../../app/services/rails_pulse/finding_detector", __dir__)
   autoload :OperationSuggestions, File.expand_path("../../app/services/rails_pulse/operation_suggestions", __dir__)
   autoload :RoutePathNormalizer,             File.expand_path("../../app/services/rails_pulse/route_path_normalizer", __dir__)
   autoload :RouteRecognizer,                 File.expand_path("../../app/services/rails_pulse/route_recognizer", __dir__)

--- a/test/dummy/db/rails_pulse_schema.rb
+++ b/test/dummy/db/rails_pulse_schema.rb
@@ -7,7 +7,7 @@ require "rails_pulse/route_indexes" unless defined?(RailsPulse::RouteIndexes)
 RailsPulse::Schema = lambda do |connection|
   adapter = connection.adapter_name.downcase
   # Skip if all tables already exist to prevent conflicts
-  required_tables = [ :rails_pulse_routes, :rails_pulse_queries, :rails_pulse_requests, :rails_pulse_operations, :rails_pulse_jobs, :rails_pulse_job_runs, :rails_pulse_summaries, :rails_pulse_deployments, :rails_pulse_exception_groups, :rails_pulse_exception_occurrences ]
+  required_tables = [ :rails_pulse_routes, :rails_pulse_queries, :rails_pulse_requests, :rails_pulse_operations, :rails_pulse_jobs, :rails_pulse_job_runs, :rails_pulse_summaries, :rails_pulse_deployments, :rails_pulse_exception_groups, :rails_pulse_exception_occurrences, :rails_pulse_findings ]
 
   # Check which tables already exist
   existing_tables = required_tables.select { |table| connection.table_exists?(table) }
@@ -257,6 +257,36 @@ RailsPulse::Schema = lambda do |connection|
 
     connection.add_index :rails_pulse_exception_occurrences, :occurred_at,        name: "index_rp_exception_occurrences_on_occurred_at"
     connection.add_index :rails_pulse_exception_occurrences, :exception_group_id, name: "index_rp_exception_occurrences_on_group_id"
+  end
+
+  unless connection.table_exists?(:rails_pulse_findings)
+    connection.create_table :rails_pulse_findings do |t|
+      t.string   :fingerprint,  null: false, comment: "SHA256 of kind + subject + metric — stable identity across detection runs"
+      t.string   :kind,         null: false, comment: "What was detected, e.g. performance_regression"
+      t.string   :subject_type, null: false, comment: "RailsPulse::Route, RailsPulse::Query, RailsPulse::Job or RailsPulse::Request"
+      t.bigint   :subject_id,   null: false, comment: "Id of the subject; 0 for the overall request rollup"
+      t.string   :metric,       null: false, comment: "p50, p95, p99, avg or error_rate"
+      t.string   :severity,     null: false, comment: "warning or critical"
+      t.string   :status,       null: false, default: "open", comment: "open, acknowledged or resolved"
+      t.float    :baseline_value, comment: "Traffic-weighted metric across the baseline window"
+      t.float    :current_value,  comment: "Metric across the window under test"
+      t.float    :delta,          comment: "current_value - baseline_value"
+      t.float    :ratio,          comment: "current_value / baseline_value"
+      t.integer  :baseline_count, comment: "Observations behind the baseline"
+      t.integer  :current_count,  comment: "Observations behind the current window"
+      t.datetime :changed_at,     comment: "Estimated change point, when one could be located"
+      t.string   :change_point_granularity, comment: "hour or day — the precision of changed_at"
+      t.datetime :first_detected_at, null: false, comment: "When this finding was first raised"
+      t.datetime :last_detected_at,  null: false, comment: "Most recent detection run that still saw it"
+      t.datetime :resolved_at,       comment: "When the finding last stopped being detected"
+      t.integer  :detection_count,   null: false, default: 0, comment: "Number of runs that have seen this finding"
+      t.timestamps
+    end
+
+    connection.add_index :rails_pulse_findings, :fingerprint, unique: true, name: "index_rails_pulse_findings_on_fingerprint"
+    connection.add_index :rails_pulse_findings, :status,                    name: "index_rails_pulse_findings_on_status"
+    connection.add_index :rails_pulse_findings, :last_detected_at,          name: "index_rails_pulse_findings_on_last_detected_at"
+    connection.add_index :rails_pulse_findings, [ :subject_type, :subject_id ], name: "index_rails_pulse_findings_on_subject"
   end
 
   # Add indexes to existing tables for efficient aggregation

--- a/test/fixtures/rails_pulse_findings.yml
+++ b/test/fixtures/rails_pulse_findings.yml
@@ -1,0 +1,88 @@
+# Findings are written by FindingDetector, never by hand in production. These
+# fixtures exist so views and dashboard code have something to render without
+# each test having to build a full baseline history first.
+
+open_route_regression:
+  fingerprint: <%= Digest::SHA256.hexdigest("performance_regression:RailsPulse::Route:1:p95") %>
+  kind: "performance_regression"
+  subject_type: "RailsPulse::Route"
+  subject_id: 1
+  metric: "p95"
+  severity: "critical"
+  status: "open"
+  baseline_value: 220.0
+  current_value: 1420.0
+  delta: 1200.0
+  ratio: 6.4545
+  baseline_count: 42000
+  current_count: 1800
+  changed_at: <%= 2.days.ago.beginning_of_hour %>
+  change_point_granularity: "hour"
+  first_detected_at: <%= 2.days.ago %>
+  last_detected_at: <%= 1.hour.ago %>
+  detection_count: 3
+  created_at: <%= 2.days.ago %>
+  updated_at: <%= 1.hour.ago %>
+
+open_query_regression:
+  fingerprint: <%= Digest::SHA256.hexdigest("performance_regression:RailsPulse::Query:1:p95") %>
+  kind: "performance_regression"
+  subject_type: "RailsPulse::Query"
+  subject_id: 1
+  metric: "p95"
+  severity: "warning"
+  status: "open"
+  baseline_value: 40.0
+  current_value: 120.0
+  delta: 80.0
+  ratio: 3.0
+  baseline_count: 90000
+  current_count: 3100
+  changed_at: <%= 5.days.ago.beginning_of_day %>
+  change_point_granularity: "day"
+  first_detected_at: <%= 5.days.ago %>
+  last_detected_at: <%= 1.hour.ago %>
+  detection_count: 5
+  created_at: <%= 5.days.ago %>
+  updated_at: <%= 1.hour.ago %>
+
+acknowledged_error_rate_regression:
+  fingerprint: <%= Digest::SHA256.hexdigest("error_rate_regression:RailsPulse::Route:2:error_rate") %>
+  kind: "error_rate_regression"
+  subject_type: "RailsPulse::Route"
+  subject_id: 2
+  metric: "error_rate"
+  severity: "critical"
+  status: "acknowledged"
+  baseline_value: 0.8
+  current_value: 12.5
+  delta: 11.7
+  ratio: 15.625
+  baseline_count: 26000
+  current_count: 1100
+  first_detected_at: <%= 3.days.ago %>
+  last_detected_at: <%= 2.hours.ago %>
+  detection_count: 4
+  created_at: <%= 3.days.ago %>
+  updated_at: <%= 2.hours.ago %>
+
+resolved_route_regression:
+  fingerprint: <%= Digest::SHA256.hexdigest("performance_regression:RailsPulse::Route:3:p95") %>
+  kind: "performance_regression"
+  subject_type: "RailsPulse::Route"
+  subject_id: 3
+  metric: "p95"
+  severity: "warning"
+  status: "resolved"
+  baseline_value: 180.0
+  current_value: 460.0
+  delta: 280.0
+  ratio: 2.5556
+  baseline_count: 15000
+  current_count: 700
+  first_detected_at: <%= 20.days.ago %>
+  last_detected_at: <%= 12.days.ago %>
+  resolved_at: <%= 11.days.ago %>
+  detection_count: 8
+  created_at: <%= 20.days.ago %>
+  updated_at: <%= 11.days.ago %>

--- a/test/generators/base_methods_test.rb
+++ b/test/generators/base_methods_test.rb
@@ -42,8 +42,8 @@ class BaseMethodsTest < ActiveSupport::TestCase
     assert_predicate RailsPulse::Generators::BaseMethods::RAILS_PULSE_TABLES, :frozen?
   end
 
-  test "RAILS_PULSE_TABLES has 10 entries" do
-    assert_equal 10, RailsPulse::Generators::BaseMethods::RAILS_PULSE_TABLES.size
+  test "RAILS_PULSE_TABLES has 11 entries" do
+    assert_equal 11, RailsPulse::Generators::BaseMethods::RAILS_PULSE_TABLES.size
   end
 
   # next_migration_number Tests

--- a/test/migrations/upgrade_migration_test.rb
+++ b/test/migrations/upgrade_migration_test.rb
@@ -31,6 +31,7 @@ class UpgradeMigrationTest < ActiveSupport::TestCase
     ChangeRailsPulseRoutesToMultiVerbModel
     AddNullActionUniqueIndexToRoutes
     AddLocationToExceptionGroups
+    CreateRailsPulseFindings
   ].freeze
 
   def setup
@@ -293,6 +294,19 @@ class UpgradeMigrationTest < ActiveSupport::TestCase
     assert @conn.column_exists?(:rails_pulse_exception_occurrences, :occurred_at), "occurred_at missing on occurrences"
   end
 
+  test "upgrade from v0.2.7 creates the findings table" do
+    load_baseline(RailsPulse::TestSchemas::V027)
+    run_all_migrations
+
+    assert @conn.table_exists?(:rails_pulse_findings), "findings table missing"
+    assert @conn.column_exists?(:rails_pulse_findings, :fingerprint), "fingerprint missing on findings"
+    assert @conn.column_exists?(:rails_pulse_findings, :kind), "kind missing on findings"
+    assert @conn.column_exists?(:rails_pulse_findings, :subject_type), "subject_type missing on findings"
+    assert @conn.column_exists?(:rails_pulse_findings, :subject_id), "subject_id missing on findings"
+    assert @conn.column_exists?(:rails_pulse_findings, :status), "status missing on findings"
+    assert @conn.column_exists?(:rails_pulse_findings, :changed_at), "changed_at missing on findings"
+  end
+
   test "upgrade from v0.2.7 adds actual_sql to operations" do
     load_baseline(RailsPulse::TestSchemas::V027)
     run_all_migrations
@@ -340,6 +354,7 @@ class UpgradeMigrationTest < ActiveSupport::TestCase
     assert @conn.table_exists?(:rails_pulse_exception_groups)
     assert @conn.table_exists?(:rails_pulse_exception_occurrences)
     assert @conn.table_exists?(:rails_pulse_job_runs)
+    assert @conn.table_exists?(:rails_pulse_findings)
     assert @conn.column_exists?(:rails_pulse_operations, :actual_sql)
     assert @conn.column_exists?(:rails_pulse_jobs, :p95_duration)
   end

--- a/test/models/rails_pulse/dashboard/needs_attention_test.rb
+++ b/test/models/rails_pulse/dashboard/needs_attention_test.rb
@@ -7,6 +7,9 @@ module RailsPulse
 
       def setup
         RailsPulse::Summary.delete_all
+        # Findings are loaded globally by `fixtures :all`; clear them so a test
+        # only sees the regressions it creates itself.
+        RailsPulse::Finding.delete_all
         # Zero out all jobs so they don't appear in results unless the test creates them
         RailsPulse::Job.update_all(runs_count: 0, failures_count: 0, p95_duration: nil)
         # Neutralize the query_with_issues fixture so it doesn't pollute unrelated tests
@@ -353,6 +356,128 @@ module RailsPulse
         route_items = (result[:critical] + result[:warning]).select { |i| i[:name] == "/api/users" }
 
         assert_equal 1, route_items.size
+      end
+
+      # Regression Tests
+
+      # Regressions answer "what got worse?" where every other rule here answers
+      # "what is slow?". A route well under its threshold that tripled is
+      # invisible to the threshold rules and must still surface.
+
+      def create_finding(severity: "warning", ratio: 3.0, subject: nil, **overrides)
+        route = subject || rails_pulse_routes(:api_users)
+
+        RailsPulse::Finding.create!({
+          fingerprint:       SecureRandom.hex(32),
+          kind:              "performance_regression",
+          subject_type:      "RailsPulse::Route",
+          subject_id:        route.id,
+          metric:            "p95",
+          severity:          severity,
+          status:            "open",
+          baseline_value:    100.0,
+          current_value:     100.0 * ratio,
+          delta:             100.0 * (ratio - 1),
+          ratio:             ratio,
+          baseline_count:    5000,
+          current_count:     500,
+          first_detected_at: 2.days.ago,
+          last_detected_at:  1.hour.ago,
+          detection_count:   2
+        }.merge(overrides))
+      end
+
+      test "surfaces an unresolved regression" do
+        create_overall_hourly_summary(period_end: 30.minutes.ago)
+        create_finding
+
+        result = RailsPulse::Dashboard::NeedsAttention.new.to_attention_data
+        item = (result[:critical] + result[:warning]).find { |i| i[:type] == "REGRESSION" }
+
+        assert_not_nil item
+        assert_equal "/api/users", item[:name]
+        assert_equal "200% worse", item[:metric]
+      end
+
+      test "surfaces a regression on a route that is nowhere near its threshold" do
+        create_overall_hourly_summary(period_end: 30.minutes.ago)
+        # 100ms to 300ms: far below the 500ms slow threshold, so no threshold
+        # rule would ever report it.
+        create_finding(ratio: 3.0)
+
+        result = RailsPulse::Dashboard::NeedsAttention.new.to_attention_data
+
+        assert_equal 1, result[:total]
+      end
+
+      test "does not surface a resolved regression" do
+        create_overall_hourly_summary(period_end: 30.minutes.ago)
+        create_finding(status: "resolved", resolved_at: 1.day.ago)
+
+        result = RailsPulse::Dashboard::NeedsAttention.new.to_attention_data
+
+        assert_equal 0, result[:total]
+      end
+
+      test "surfaces an acknowledged regression" do
+        create_overall_hourly_summary(period_end: 30.minutes.ago)
+        create_finding(status: "acknowledged")
+
+        result = RailsPulse::Dashboard::NeedsAttention.new.to_attention_data
+
+        assert_equal 1, result[:total]
+      end
+
+      test "a critical regression lands in the critical bucket" do
+        create_overall_hourly_summary(period_end: 30.minutes.ago)
+        create_finding(severity: "critical")
+
+        result = RailsPulse::Dashboard::NeedsAttention.new.to_attention_data
+
+        assert_equal 1, result[:critical].size
+        assert_empty result[:warning]
+      end
+
+      test "a regression with a known change point says when it started" do
+        create_overall_hourly_summary(period_end: 30.minutes.ago)
+        create_finding(changed_at: 3.days.ago.beginning_of_day, change_point_granularity: "day")
+
+        result = RailsPulse::Dashboard::NeedsAttention.new.to_attention_data
+        item = (result[:critical] + result[:warning]).find { |i| i[:type] == "REGRESSION" }
+
+        assert_includes item[:reason], "started around"
+      end
+
+      test "a regression with no change point still reports the regression" do
+        create_overall_hourly_summary(period_end: 30.minutes.ago)
+        create_finding(changed_at: nil, change_point_granularity: nil)
+
+        result = RailsPulse::Dashboard::NeedsAttention.new.to_attention_data
+        item = (result[:critical] + result[:warning]).find { |i| i[:type] == "REGRESSION" }
+
+        assert_includes item[:reason], "vs its own baseline"
+      end
+
+      test "regressions are subject to the same 10-item cap" do
+        create_overall_hourly_summary(period_end: 30.minutes.ago)
+        routes = [
+          rails_pulse_routes(:api_users),
+          rails_pulse_routes(:api_posts),
+          rails_pulse_routes(:api_test),
+          rails_pulse_routes(:api_other),
+          rails_pulse_routes(:api_cleanup)
+        ]
+        # Two findings per route on different metrics, for 10, plus two more.
+        routes.each do |route|
+          create_finding(subject: route, metric: "p95")
+          create_finding(subject: route, metric: "error_rate", kind: "error_rate_regression")
+        end
+        create_finding(subject: routes.first, metric: "p99")
+        create_finding(subject: routes.last, metric: "p50")
+
+        result = RailsPulse::Dashboard::NeedsAttention.new.to_attention_data
+
+        assert_operator result[:total], :<=, 10
       end
 
       # Edge Cases

--- a/test/models/rails_pulse/finding_test.rb
+++ b/test/models/rails_pulse/finding_test.rb
@@ -1,0 +1,144 @@
+require "test_helper"
+
+module RailsPulse
+  class FindingTest < ActiveSupport::TestCase
+    fixtures :rails_pulse_findings, :rails_pulse_routes
+
+    # Structure Tests
+
+    test "requires a fingerprint" do
+      finding = build_finding(fingerprint: nil)
+
+      assert_not finding.valid?
+      assert_includes finding.errors[:fingerprint], "can't be blank"
+    end
+
+    test "fingerprints are unique" do
+      existing = rails_pulse_findings(:open_route_regression)
+      duplicate = build_finding(fingerprint: existing.fingerprint)
+
+      assert_not duplicate.valid?
+    end
+
+    test "rejects an unknown status" do
+      assert_not build_finding(status: "snoozed").valid?
+    end
+
+    test "rejects an unknown severity" do
+      assert_not build_finding(severity: "catastrophic").valid?
+    end
+
+    test "rejects an unknown kind" do
+      assert_not build_finding(kind: "vibes").valid?
+    end
+
+    # Scope Tests
+
+    test "unresolved covers open and acknowledged but not resolved" do
+      statuses = Finding.unresolved.pluck(:status).uniq.sort
+
+      assert_equal %w[acknowledged open], statuses
+    end
+
+    test "resolved returns only resolved findings" do
+      assert_equal [ "resolved" ], Finding.resolved.pluck(:status).uniq
+    end
+
+    test "recent orders by most recently detected" do
+      timestamps = Finding.recent.pluck(:last_detected_at)
+
+      assert_equal timestamps.sort.reverse, timestamps
+    end
+
+    # Fingerprint Tests
+
+    test "fingerprint_for is stable for the same inputs" do
+      args = { kind: "performance_regression", subject_type: "RailsPulse::Route", subject_id: 7, metric: "p95" }
+
+      assert_equal Finding.fingerprint_for(**args), Finding.fingerprint_for(**args)
+    end
+
+    test "fingerprint_for separates subjects" do
+      one = Finding.fingerprint_for(kind: "performance_regression", subject_type: "RailsPulse::Route", subject_id: 7, metric: "p95")
+      two = Finding.fingerprint_for(kind: "performance_regression", subject_type: "RailsPulse::Route", subject_id: 8, metric: "p95")
+
+      assert_not_equal one, two
+    end
+
+    # Presentation Tests
+
+    test "percent_change derives from the ratio" do
+      finding = rails_pulse_findings(:open_query_regression)
+
+      assert_in_delta 200.0, finding.percent_change, 0.01
+    end
+
+    test "unit is milliseconds for duration metrics" do
+      assert_equal "ms", rails_pulse_findings(:open_route_regression).unit
+    end
+
+    test "unit is percent for error rate" do
+      assert_equal "%", rails_pulse_findings(:acknowledged_error_rate_regression).unit
+    end
+
+    test "change point precision is reported" do
+      hourly = rails_pulse_findings(:open_route_regression)
+      daily  = rails_pulse_findings(:open_query_regression)
+
+      assert_predicate hourly, :hourly_change_point?
+      assert_not_predicate daily, :hourly_change_point?
+      assert_predicate daily, :change_point_known?
+    end
+
+    test "a finding with no change point says so" do
+      finding = rails_pulse_findings(:acknowledged_error_rate_regression)
+
+      assert_not_predicate finding, :change_point_known?
+    end
+
+    test "subject_label falls back when the subject has been cleaned up" do
+      finding = build_finding(subject_id: 999_999)
+
+      assert_equal "Route #999999", finding.subject_label
+    end
+
+    test "the overall request rollup has no record and is labelled" do
+      finding = build_finding(subject_type: "RailsPulse::Request", subject_id: 0)
+
+      assert_predicate finding, :overall_requests?
+      assert_nil finding.subject
+      assert_equal "All requests", finding.subject_label
+    end
+
+    test "to_s renders both sides of the change" do
+      finding = rails_pulse_findings(:open_route_regression)
+
+      assert_includes finding.to_s, "220ms"
+      assert_includes finding.to_s, "1420ms"
+    end
+
+    # Ransack Tests
+
+    test "exposes ransackable attributes" do
+      assert_includes Finding.ransackable_attributes, "severity"
+      assert_includes Finding.ransackable_attributes, "status"
+      assert_includes Finding.ransackable_attributes, "last_detected_at"
+    end
+
+    private
+
+    def build_finding(**overrides)
+      Finding.new({
+        fingerprint:       SecureRandom.hex(32),
+        kind:              "performance_regression",
+        subject_type:      "RailsPulse::Route",
+        subject_id:        1,
+        metric:            "p95",
+        severity:          "warning",
+        status:            "open",
+        first_detected_at: Time.current,
+        last_detected_at:  Time.current
+      }.merge(overrides))
+    end
+  end
+end

--- a/test/services/rails_pulse/finding_detector_test.rb
+++ b/test/services/rails_pulse/finding_detector_test.rb
@@ -1,0 +1,238 @@
+require "test_helper"
+
+module RailsPulse
+  class FindingDetectorTest < ActiveSupport::TestCase
+    fixtures :rails_pulse_routes
+
+    def setup
+      @route = rails_pulse_routes(:api_users)
+      @now   = Time.utc(2026, 6, 15, 12, 0, 0)
+      travel_to @now
+      RailsPulse::Summary.delete_all
+      RailsPulse::Finding.delete_all
+    end
+
+    def teardown
+      travel_back
+    end
+
+    def summary_for(days_ago, p95:, count: 500, error_count: 0, route: nil)
+      period_start = (@now - days_ago.days).beginning_of_day
+
+      RailsPulse::Summary.create!(
+        summarizable_type: "RailsPulse::Route",
+        summarizable_id:   (route || @route).id,
+        period_type:       "day",
+        period_start:      period_start,
+        period_end:        period_start.end_of_day,
+        count:             count,
+        avg_duration:      p95 * 0.6,
+        p50_duration:      p95 * 0.5,
+        p95_duration:      p95,
+        p99_duration:      p95 * 1.2,
+        error_count:       error_count,
+        success_count:     count - error_count
+      )
+    end
+
+    # A steady baseline followed by a regressed final complete day.
+    def regressed_route(baseline: 200.0, current: 900.0, route: nil)
+      (2..11).each { |ago| summary_for(ago, p95: baseline, route: route) }
+      summary_for(1, p95: current, route: route)
+    end
+
+    def healthy_route(p95: 200.0, route: nil)
+      (1..11).each { |ago| summary_for(ago, p95: p95, route: route) }
+    end
+
+    # Structure Tests
+
+    test "records a finding for a detected regression" do
+      regressed_route
+
+      result = FindingDetector.call(as_of: @now)
+
+      assert_equal 1, result.detected
+      assert_equal 1, result.opened
+
+      finding = Finding.sole
+
+      assert_equal "performance_regression", finding.kind
+      assert_equal "RailsPulse::Route", finding.subject_type
+      assert_equal @route.id, finding.subject_id
+      assert_equal "p95", finding.metric
+      assert_equal "open", finding.status
+      assert_in_delta 200.0, finding.baseline_value, 0.01
+      assert_in_delta 900.0, finding.current_value, 0.01
+    end
+
+    test "records nothing when nothing regressed" do
+      healthy_route
+
+      result = FindingDetector.call(as_of: @now)
+
+      assert_equal 0, result.detected
+      assert_empty Finding.all
+    end
+
+    test "returns a result describing the run" do
+      regressed_route
+
+      result = FindingDetector.call(as_of: @now)
+
+      assert_equal 1, result.detected
+      assert_equal 1, result.opened
+      assert_equal 0, result.reopened
+      assert_equal 0, result.resolved
+    end
+
+    # Identity Tests
+
+    test "re-detecting updates the existing finding rather than adding a row" do
+      regressed_route
+      # Still regressed the following day, so the second run sees it again.
+      summary_for(0, p95: 900.0)
+
+      FindingDetector.call(as_of: @now)
+      FindingDetector.call(as_of: @now + 1.day)
+
+      assert_equal 1, Finding.count
+      assert_equal 2, Finding.sole.detection_count
+    end
+
+    test "first_detected_at is preserved across runs" do
+      regressed_route
+      summary_for(0, p95: 900.0)
+
+      FindingDetector.call(as_of: @now)
+      original = Finding.sole.first_detected_at
+
+      FindingDetector.call(as_of: @now + 1.day)
+
+      assert_equal original, Finding.sole.first_detected_at
+      assert_equal @now + 1.day, Finding.sole.last_detected_at
+    end
+
+    test "fingerprint separates metrics on the same subject" do
+      one = Finding.fingerprint_for(kind: "performance_regression", subject_type: "RailsPulse::Route", subject_id: 1, metric: "p95")
+      two = Finding.fingerprint_for(kind: "error_rate_regression",  subject_type: "RailsPulse::Route", subject_id: 1, metric: "error_rate")
+
+      assert_not_equal one, two
+    end
+
+    # Lifecycle Tests
+
+    test "resolves a finding that stops being detected" do
+      regressed_route
+      FindingDetector.call(as_of: @now)
+
+      assert_equal "open", Finding.sole.status
+
+      # The regression clears: the last complete day is back to baseline.
+      RailsPulse::Summary.delete_all
+      healthy_route
+
+      result = FindingDetector.call(as_of: @now)
+
+      assert_equal 1, result.resolved
+      assert_equal "resolved", Finding.sole.status
+      assert_equal @now, Finding.sole.resolved_at
+    end
+
+    test "reopens a resolved finding rather than creating a second one" do
+      regressed_route
+      FindingDetector.call(as_of: @now)
+
+      RailsPulse::Summary.delete_all
+      healthy_route
+      FindingDetector.call(as_of: @now)
+
+      assert_equal "resolved", Finding.sole.status
+
+      RailsPulse::Summary.delete_all
+      regressed_route
+      result = FindingDetector.call(as_of: @now)
+
+      assert_equal 1, result.reopened
+      assert_equal 1, Finding.count
+      assert_equal "open", Finding.sole.status
+      assert_nil Finding.sole.resolved_at
+    end
+
+    test "resolving does not touch findings the run did detect" do
+      regressed_route
+      FindingDetector.call(as_of: @now)
+      FindingDetector.call(as_of: @now)
+
+      assert_equal "open", Finding.sole.status
+      assert_nil Finding.sole.resolved_at
+    end
+
+    # Severity Tests
+
+    test "a regression landing above the critical threshold is critical" do
+      # Default route critical threshold is 3000ms.
+      regressed_route(baseline: 500.0, current: 4000.0)
+
+      FindingDetector.call(as_of: @now)
+
+      assert_equal "critical", Finding.sole.severity
+    end
+
+    test "a regression landing below the critical threshold is a warning" do
+      regressed_route(baseline: 200.0, current: 700.0)
+
+      FindingDetector.call(as_of: @now)
+
+      assert_equal "warning", Finding.sole.severity
+    end
+
+    # Change Point Tests
+
+    test "records the change point and its precision when one is found" do
+      regressed_route
+
+      FindingDetector.call(as_of: @now)
+      finding = Finding.sole
+
+      assert_predicate finding, :change_point_known?
+      assert_equal "day", finding.change_point_granularity
+      assert_not_predicate finding, :hourly_change_point?
+    end
+
+    # Configuration Tests
+
+    test "skips jobs when job tracking is disabled" do
+      original = RailsPulse.configuration.track_jobs
+      RailsPulse.configuration.track_jobs = false
+
+      regressed_route
+      FindingDetector.call(as_of: @now)
+
+      assert_empty Finding.where(subject_type: "RailsPulse::Job")
+    ensure
+      RailsPulse.configuration.track_jobs = original
+    end
+
+    # Edge Cases
+
+    test "does nothing with no summaries at all" do
+      result = FindingDetector.call(as_of: @now)
+
+      assert_equal 0, result.detected
+      assert_equal 0, result.opened
+      assert_equal 0, result.resolved
+    end
+
+    test "detects independently across several subjects" do
+      other = rails_pulse_routes(:api_posts)
+      regressed_route
+      regressed_route(route: other)
+
+      result = FindingDetector.call(as_of: @now)
+
+      assert_equal 2, result.detected
+      assert_equal 2, Finding.count
+    end
+  end
+end


### PR DESCRIPTION
**Step 2 of 4** in the OSS V1 track. Stacked on #207 — **base that first**, this PR targets `oss-v1/baseline-comparison`, not `main`.

## Why

`Dashboard::NeedsAttention` is already closer to a findings engine than its name suggests: it classifies routes, queries, jobs and storage pressure into severity tiers, computes a sort score, caps the app-level list at ten while letting infrastructure signals bypass the cap, and folds in analysed queries with stored critical issues. Two structural limits stop it being what V1 needs.

**Every rule is an absolute threshold.** `p95 >= route_thresholds[:critical]`, `error_rate >= CRITICAL_ERROR_RATE`, `failure_rate >= CRITICAL_JOB_FAILURE_RATE`. A route that tripled from 90ms to 280ms is invisible; a route that has always been slow is reported forever. It detects *slowness*, never *change*.

**Findings are computed at render time and thrown away.** There's no record, so a finding can't be trended, acknowledged, dismissed, linked to a deployment, or read back by anything other than the page that computed it.

## What this adds

`rails_pulse_findings` + `RailsPulse::FindingDetector`, which runs the deterministic regression rules from `Operations::Compare` over every route and query (and jobs, when `track_jobs` is on) and records what it finds.

`NeedsAttention` now surfaces unresolved findings alongside its threshold items — a `REGRESSION` item type showing percent change and, where a change point was located, roughly when it started.

## Design decisions worth reviewing

**Lifecycle mirrors `ExceptionGroup`,** because it's the same problem and the pattern is already proven in this codebase. Identity is *the thing being reported*, not the run that reported it — a route that keeps regressing is one finding that keeps being seen, not a row per detection run. A finding that stops being detected resolves itself; if it comes back it **reopens** rather than starting a second row, so the history of how often a subject regresses stays on one record.

**Severity reuses thresholds the host already tuned.** A regression is `critical` when the metric has not just moved but *landed somewhere the user already considers critical*. That avoids inventing a second severity scale they'd have to learn.

**Detection runs once a day, from `SummaryJob` after its daily rollup.** Baselines are built from day summaries, so there is genuinely nothing new to compare against until the next one lands — running hourly would burn queries to reach the same answer. It's wrapped so detection failing cannot take the summary job down with it: summaries are the data everything depends on, findings are derived from them.

**Only resolved findings are prunable.** An unresolved finding is a live statement about current behaviour, so it stays until detection says otherwise regardless of age. Count-based cleanup scopes to `resolved`.

**`NeedsAttention` guards on `table_exists?`** so a host that has upgraded the gem but not yet run migrations still gets a working dashboard rather than a 500.

## Schema

New table, all five paths per CLAUDE.md: source schema, generator template (verified byte-identical), incremental migration with `table_exists?`/`index_exists?` guards, `RAILS_PULSE_TABLES`, and `upgrade_migration_test.rb` (registry + a new assertion + the idempotency test). Dummy schema synced via `rake sync_test_schema`.

Migration name uses full words — `create_rails_pulse_findings` — no acronyms, per the inflection hazard in CLAUDE.md.

`rails_pulse_findings: 1_000` added to `max_table_records`. Existing installs are unaffected: the setter merges over defaults, so a host initializer that doesn't mention the key still gets it.

## One thing reviewers should push back on if they disagree

`FindingDetector` scans **routes and queries always, jobs only when `track_jobs` is on**. Scanning jobs with tracking off would produce findings for a table that stopped being written to — which reads as a regression nobody can act on. If job findings should appear for hosts that *used* to track jobs, that's a different call.

## Tests

34 new tests (15 detector, 19 model) plus 8 new `NeedsAttention` regression tests and a new migration assertion.

Full suite green: **3200 runs, 8741 assertions, 0 failures, 0 errors**, plus **22 migration tests**. RuboCop clean.

Two existing tests changed, both because `fixtures :all` loads the new findings fixtures everywhere: `NeedsAttentionTest#setup` now clears findings the way it already clears summaries and zeroes jobs, and `BaseMethodsTest` asserts 11 tables instead of 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BaximWeiDUL64Mr5RXWi4n