### PR TITLE
Exceptions: summaries, dashboard integration, and a frequency view

### DIFF
--- a/app/controllers/rails_pulse/exceptions_controller.rb
+++ b/app/controllers/rails_pulse/exceptions_controller.rb
@@ -1,5 +1,8 @@
 module RailsPulse
   class ExceptionsController < ApplicationController
+    include TimeRangeConcern
+    include TagFilterConcern
+
     before_action :set_exception_group, only: %i[show update]
 
     def index
@@ -9,6 +12,8 @@ module RailsPulse
       @ransack_query = ExceptionGroup.ransack(ransack_params)
       @ransack_query.sorts = "last_seen_at desc" if @ransack_query.sorts.empty?
       @pagination, @table_data = paginate(@ransack_query.result, limit: session_pagination_limit)
+
+      setup_frequency_view
     end
 
     def show
@@ -26,6 +31,31 @@ module RailsPulse
     end
 
     private
+
+    # The index is a list of groups, not an aggregate table, so it does not use
+    # ChartTableConcern. It still needs a time range and a frequency series:
+    # without them the page can say what is failing but not whether it is
+    # getting worse, which is the question users actually arrive with.
+    def setup_frequency_view
+      start_timestamp, end_timestamp, @selected_time_range, time_diff = setup_time_range
+
+      @start_time  = Time.zone.at(start_timestamp)
+      @end_time    = Time.zone.at(end_timestamp)
+      @period_type = time_diff <= 25 ? "hour" : "day"
+      period_days  = [ ((@end_time - @start_time) / 1.day).ceil, 1 ].max
+
+      @occurrence_volume_chart = Exceptions::Charts::OccurrenceVolume.new(
+        start_time: @start_time, end_time: @end_time, period_type: @period_type
+      ).to_chart_data
+
+      @total_occurrences_metric_card = Exceptions::Cards::TotalOccurrences.new(
+        period: period_days, period_type: @period_type
+      ).to_metric_card
+
+      @open_groups_metric_card = Exceptions::Cards::OpenGroups.new(
+        period: period_days, period_type: @period_type
+      ).to_metric_card
+    end
 
     def set_exception_group
       @exception_group = ExceptionGroup.find(params[:id])

--- a/app/models/rails_pulse/dashboard/health_summary.rb
+++ b/app/models/rails_pulse/dashboard/health_summary.rb
@@ -11,6 +11,7 @@ module RailsPulse
         @route_thresholds = RailsPulse.configuration.route_thresholds
         @query_thresholds = RailsPulse.configuration.query_thresholds
         @job_thresholds   = RailsPulse.configuration.job_thresholds
+        @exception_thresholds = RailsPulse.configuration.exception_thresholds
       end
 
       def to_health_data
@@ -18,6 +19,7 @@ module RailsPulse
           routes:   route_counts,
           queries:  query_counts,
           jobs:     job_counts,
+          exceptions: exception_counts,
           storage:  storage_counts
         }
       end
@@ -107,6 +109,56 @@ module RailsPulse
         end
 
         { healthy: healthy, slow: slow, critical: critical }
+      end
+
+      # Exception groups classified by how often they fired over the dashboard
+      # period, read from summaries rather than from ExceptionGroup's lifetime
+      # occurrence_count — a group that fired ten thousand times last year and
+      # is now silent is not a critical problem today.
+      #
+      # A group with occurrences in the period but below the warning threshold
+      # counts as "slow" rather than "healthy": an exception happening at all is
+      # not healthy, it is just not yet urgent.
+      def exception_counts
+        return nil unless RailsPulse.configuration.track_exceptions
+        return nil unless exception_summaries_available?
+
+        start, finish = period_range
+
+        counts = RailsPulse::Summary
+          .for_exceptions
+          .where.not(summarizable_id: 0)
+          .where(period_start: start..finish)
+          .group(:summarizable_id)
+          .sum(:count)
+
+        healthy = slow = critical = 0
+
+        open_group_ids.each do |group_id|
+          occurrences = counts[group_id].to_i
+
+          if occurrences >= @exception_thresholds[:critical]
+            critical += 1
+          elsif occurrences >= @exception_thresholds[:warning]
+            slow += 1
+          elsif occurrences.positive?
+            slow += 1
+          else
+            healthy += 1
+          end
+        end
+
+        { healthy: healthy, slow: slow, critical: critical }
+      end
+
+      def open_group_ids
+        RailsPulse::ExceptionGroup.where(status: "open").pluck(:id)
+      end
+
+      def exception_summaries_available?
+        RailsPulse::ExceptionGroup.table_exists?
+      rescue ActiveRecord::ActiveRecordError
+        false
       end
     end
   end

--- a/app/models/rails_pulse/dashboard/needs_attention.rb
+++ b/app/models/rails_pulse/dashboard/needs_attention.rb
@@ -11,12 +11,13 @@ module RailsPulse
         @route_thresholds = RailsPulse.configuration.route_thresholds
         @query_thresholds = RailsPulse.configuration.query_thresholds
         @job_thresholds   = RailsPulse.configuration.job_thresholds
+        @exception_thresholds = RailsPulse.configuration.exception_thresholds
       end
 
       MAX_ITEMS = 10
 
       def to_attention_data
-        items    = regression_items + route_items + query_items + job_items
+        items    = regression_items + route_items + query_items + job_items + exception_items
         critical = items.select { |i| i[:severity] == :critical }.sort_by { |i| -i[:sort_score] }
         warning  = items.select { |i| i[:severity] == :warning  }.sort_by { |i| -i[:sort_score] }
 
@@ -299,6 +300,75 @@ module RailsPulse
               p95 ]
           end
         end
+      end
+
+      # Exception groups that fired often enough over the period to be worth
+      # looking at. Read from summaries, not from ExceptionGroup#occurrence_count
+      # — that is a lifetime counter, so a group that was noisy last year and is
+      # silent now would otherwise be reported forever.
+      #
+      # Ignored groups are excluded by design: a user marking something ignored
+      # is saying "stop telling me about this", and the attention list is
+      # exactly where that must be honoured.
+      def exception_items
+        return [] unless RailsPulse.configuration.track_exceptions
+        return [] unless exception_tables_available?
+
+        start, finish = period_range
+
+        counts = RailsPulse::Summary
+          .for_exceptions
+          .where.not(summarizable_id: 0)
+          .where(period_start: start..finish)
+          .group(:summarizable_id)
+          .sum(:count)
+
+        return [] if counts.empty?
+
+        groups = RailsPulse::ExceptionGroup
+          .where(id: counts.keys, status: %w[open])
+          .index_by(&:id)
+
+        counts.filter_map do |group_id, occurrences|
+          group = groups[group_id]
+          next if group.nil?
+
+          severity = exception_severity(occurrences)
+          next if severity.nil?
+
+          {
+            type:       "EXCEPTION",
+            name:       group.exception_class,
+            reason:     "#{occurrences} occurrence#{occurrences == 1 ? "" : "s"}#{group.location.present? ? " · #{group.location}" : ""}",
+            metric:     "#{occurrences} this period",
+            metric_sub: group.last_seen_at ? "last seen #{time_ago_phrase(group.last_seen_at)}" : "open",
+            link:       url_helpers.exception_path(group.id),
+            severity:   severity,
+            sort_score: occurrences.to_f
+          }
+        end
+      end
+
+      def exception_severity(occurrences)
+        return :critical if occurrences >= @exception_thresholds[:critical]
+        return :warning  if occurrences >= @exception_thresholds[:warning]
+
+        nil
+      end
+
+      def time_ago_phrase(time)
+        seconds = (Time.current - time).to_i
+        return "just now" if seconds < 60
+        return "#{seconds / 60}m ago" if seconds < 3600
+        return "#{seconds / 3600}h ago" if seconds < 86_400
+
+        "#{seconds / 86_400}d ago"
+      end
+
+      def exception_tables_available?
+        RailsPulse::ExceptionGroup.table_exists?
+      rescue ActiveRecord::ActiveRecordError
+        false
       end
 
       def truncate_sql(sql)

--- a/app/models/rails_pulse/exceptions/cards/open_groups.rb
+++ b/app/models/rails_pulse/exceptions/cards/open_groups.rb
@@ -1,0 +1,49 @@
+module RailsPulse
+  module Exceptions
+    module Cards
+      # How many distinct exception sites are currently open.
+      #
+      # Occurrence volume and open-group count answer different questions: one
+      # loud exception firing ten thousand times and a hundred different sites
+      # each firing once are both worth knowing about, and neither number tells
+      # you about the other.
+      class OpenGroups < RailsPulse::Cards::Base
+        def initialize(disabled_tags: [], show_non_tagged: true, period: 14, period_type: "day")
+          @disabled_tags   = disabled_tags
+          @show_non_tagged = show_non_tagged
+          @period          = period
+          @period_type     = period_type
+        end
+
+        def to_metric_card
+          open_count = RailsPulse::ExceptionGroup.where(status: "open").count
+
+          # New groups are the ones that did not exist before this window — a
+          # site that has just started failing, rather than a known one.
+          new_in_window = RailsPulse::ExceptionGroup
+            .where(status: "open")
+            .where(first_seen_at: current_window_start..now)
+            .count
+
+          grouped = RailsPulse::ExceptionGroup
+            .where(first_seen_at: current_window_start..now)
+            .group_by_date(:first_seen_at)
+            .count
+
+          {
+            id: "exceptions_open_groups",
+            chart_color: RailsPulse::ChartColors::DEFAULT,
+            context: "exceptions",
+            title: "Open Groups",
+            summary: "#{format_number(open_count)} open",
+            chart_data: sparkline_from(grouped),
+            trend_text: nil,
+            period_stat: "#{format_number(new_in_window)} new this period",
+            help_heading: "Open Exception Groups",
+            help_text: "Distinct exception sites currently marked open — one per exception class and code location, not one per raise. Resolved and ignored groups are excluded. The period figure counts sites seen for the first time in this window, which is usually where a new bug shows up."
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/models/rails_pulse/exceptions/cards/total_occurrences.rb
+++ b/app/models/rails_pulse/exceptions/cards/total_occurrences.rb
@@ -1,0 +1,62 @@
+module RailsPulse
+  module Exceptions
+    module Cards
+      # How often exceptions fired, and whether that is going up.
+      #
+      # This is the card that makes "which exceptions are increasing?" a
+      # question the product can answer at a glance. It reads the all-groups
+      # rollup summary rather than ExceptionGroup#occurrence_count, which is a
+      # lifetime counter and never goes down.
+      class TotalOccurrences < RailsPulse::Cards::Base
+        SUMMARIZABLE_TYPE = "RailsPulse::ExceptionGroup".freeze
+
+        def initialize(disabled_tags: [], show_non_tagged: true, period: 14, period_type: "day")
+          @disabled_tags   = disabled_tags
+          @show_non_tagged = show_non_tagged
+          @period          = period
+          @period_type     = period_type
+        end
+
+        def to_metric_card
+          base_query = RailsPulse::Summary
+            .overall_exceptions
+            .where(period_type: @period_type, period_start: range_start..now)
+
+          metrics = base_query.select(
+            "SUM(rails_pulse_summaries.count) AS total_count",
+            "SUM(CASE WHEN rails_pulse_summaries.period_start >= #{quote(current_window_start)} THEN rails_pulse_summaries.count ELSE 0 END) AS current_count",
+            "SUM(CASE WHEN rails_pulse_summaries.period_start >= #{quote(range_start)} AND rails_pulse_summaries.period_start < #{quote(current_window_start)} THEN rails_pulse_summaries.count ELSE 0 END) AS previous_count"
+          ).take
+
+          total    = metrics&.total_count.to_i
+          current  = metrics&.current_count.to_i
+          previous = metrics&.previous_count.to_i
+
+          # More exceptions is worse, so the trend arrow means the opposite of
+          # what it means on a throughput card.
+          trend_icon, trend_amount = trend_for(current, previous) if show_trend?
+
+          grouped = base_query
+            .where(period_start: current_window_start..now)
+            .group_by_date(:period_start)
+            .sum("rails_pulse_summaries.count")
+
+          {
+            id: "exceptions_total_occurrences",
+            chart_color: RailsPulse::ChartColors::DEFAULT,
+            context: "exceptions",
+            title: "Occurrences",
+            summary: "#{format_number(total)} raised",
+            chart_data: sparkline_from(grouped),
+            trend_icon: trend_icon,
+            trend_amount: trend_amount,
+            trend_text: (show_trend? ? comparison_period_text : nil),
+            period_stat: period_date_range,
+            help_heading: "Exception Occurrences",
+            help_text: "How many exceptions your application raised over the period, across every group. Read from retained summaries, so the history stays accurate even after individual occurrence records have been cleaned up. A rising trend is the signal to look at which groups are growing."
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/models/rails_pulse/exceptions/charts/occurrence_volume.rb
+++ b/app/models/rails_pulse/exceptions/charts/occurrence_volume.rb
@@ -1,0 +1,56 @@
+module RailsPulse
+  module Exceptions
+    module Charts
+      # Exception frequency over time, read from the all-groups rollup summary.
+      #
+      # Reads summaries rather than counting occurrence rows directly: occurrence
+      # rows are pruned by retention, so counting them would show a chart that
+      # silently flattens toward zero the further back you look. Summaries are
+      # retained at day granularity indefinitely.
+      class OccurrenceVolume
+        def initialize(start_time:, end_time:, period_type: "day")
+          @start_time  = start_time
+          @end_time    = end_time
+          @period_type = period_type
+        end
+
+        def to_chart_data
+          totals = RailsPulse::Summary
+            .overall_exceptions
+            .where(period_type: @period_type, period_start: @start_time..@end_time)
+            .group(:period_start)
+            .sum(:count)
+
+          return nil if totals.empty?
+
+          raw = totals.transform_keys { |period_start| period_start.to_i }
+          padded = pad_with_zeros(raw)
+
+          {
+            series: [ {
+              name: "Occurrences",
+              data: padded.map { |timestamp, value| [ timestamp * 1000, value ] },
+              type: "bar",
+              color: RailsPulse::ChartColors::DEFAULT
+            } ]
+          }
+        end
+
+        private
+
+        # A period with no exceptions produces no summary row, which is the
+        # answer "zero" rather than "no data" — leaving the gap unfilled would
+        # draw a chart that skips quiet days and misrepresents the trend.
+        def pad_with_zeros(raw)
+          step = @period_type.to_s == "hour" ? 3600 : 86_400
+
+          {}.tap do |padded|
+            (@start_time.to_i..@end_time.to_i).step(step) do |timestamp|
+              padded[timestamp] = raw[timestamp] || 0
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/rails_pulse/finding.rb
+++ b/app/models/rails_pulse/finding.rb
@@ -2,7 +2,11 @@ module RailsPulse
   class Finding < RailsPulse::ApplicationRecord
     self.table_name = "rails_pulse_findings"
 
-    KINDS = %w[performance_regression error_rate_regression].freeze
+    KINDS = %w[
+      performance_regression
+      error_rate_regression
+      exception_frequency_regression
+    ].freeze
     SEVERITIES = %w[warning critical].freeze
     STATUSES = %w[open acknowledged resolved].freeze
 
@@ -63,11 +67,16 @@ module RailsPulse
       when "RailsPulse::Route" then record.path
       when "RailsPulse::Query" then record.normalized_sql
       when "RailsPulse::Job"   then record.name
+      when "RailsPulse::ExceptionGroup" then record.exception_class
       end.presence || "#{subject_type.demodulize} ##{subject_id}"
     end
 
     def unit
-      metric == "error_rate" ? "%" : "ms"
+      case metric
+      when "error_rate" then "%"
+      when "volume"     then ""
+      else "ms"
+      end
     end
 
     def percent_change
@@ -99,7 +108,11 @@ module RailsPulse
     def format_value(value)
       return "—" if value.nil?
 
-      metric == "error_rate" ? "#{value.round(2)}%" : "#{value.round(0).to_i}ms"
+      case metric
+      when "error_rate" then "#{value.round(2)}%"
+      when "volume"     then "#{value.round(1)} per day"
+      else "#{value.round(0).to_i}ms"
+      end
     end
   end
 end

--- a/app/models/rails_pulse/summary.rb
+++ b/app/models/rails_pulse/summary.rb
@@ -30,6 +30,14 @@ module RailsPulse
     scope :for_routes, -> { where(summarizable_type: "RailsPulse::Route") }
     scope :for_queries, -> { where(summarizable_type: "RailsPulse::Query") }
     scope :for_jobs, -> { where(summarizable_type: "RailsPulse::Job") }
+    scope :for_exceptions, -> { where(summarizable_type: "RailsPulse::ExceptionGroup") }
+
+    # Frequency across every exception group, written alongside the per-group
+    # rows so a chart of total exception volume is one query rather than one
+    # per group.
+    scope :overall_exceptions, -> {
+      where(summarizable_type: "RailsPulse::ExceptionGroup", summarizable_id: 0)
+    }
     scope :by_job_name, ->(job_name) { for_jobs.joins(:job).where(rails_pulse_jobs: { name: job_name }) }
     scope :recent, -> { order(period_start: :desc) }
 
@@ -61,7 +69,8 @@ module RailsPulse
         "  (summarizable_type = 'RailsPulse::Route' AND summarizable_id IN (?)) OR " \
         "  (summarizable_type = 'RailsPulse::Query' AND summarizable_id IN (?)) OR " \
         "  (summarizable_type = 'RailsPulse::Job' AND summarizable_id IN (?)) OR " \
-        "  (summarizable_type = 'RailsPulse::Request')" \
+        "  (summarizable_type = 'RailsPulse::Request') OR " \
+        "  (summarizable_type = 'RailsPulse::ExceptionGroup')" \
         ")",
         route_ids,
         query_ids,

--- a/app/services/rails_pulse/finding_detector.rb
+++ b/app/services/rails_pulse/finding_detector.rb
@@ -18,6 +18,12 @@ module RailsPulse
       error_rate: "error_rate_regression"
     }.freeze
 
+    # Exception groups have no duration, so they are compared on how often they
+    # fire rather than how long they take.
+    EXCEPTION_METRICS = {
+      volume: "exception_frequency_regression"
+    }.freeze
+
     Result = Struct.new(:detected, :opened, :reopened, :resolved, keyword_init: true)
 
     def self.call(as_of: Time.current)
@@ -34,12 +40,13 @@ module RailsPulse
 
       subject_scopes.each do |scope|
         METRICS.each do |metric, kind|
-          Operations::Compare.scan(scope, metric: metric, as_of: as_of).each do |comparison|
-            next unless comparison.regression?
+          seen.concat(detect(scope, metric: metric, kind: kind))
+        end
+      end
 
-            seen << record(comparison, kind: kind)
-            @result.detected += 1
-          end
+      if exceptions_trackable?
+        EXCEPTION_METRICS.each do |metric, kind|
+          seen.concat(detect(exception_scope, metric: metric, kind: kind))
         end
       end
 
@@ -50,6 +57,31 @@ module RailsPulse
     private
 
     attr_reader :as_of
+
+    def detect(scope, metric:, kind:)
+      return [] if scope.nil?
+
+      Operations::Compare.scan(scope, metric: metric, as_of: as_of).filter_map do |comparison|
+        next unless comparison.regression?
+
+        @result.detected += 1
+        record(comparison, kind: kind)
+      end
+    end
+
+    # Only groups the user still cares about. A resolved or ignored group that
+    # starts firing again is handled by the capture service reopening it, so
+    # scanning ignored groups here would reintroduce exactly the noise the
+    # ignore was meant to remove.
+    def exception_scope
+      RailsPulse::ExceptionGroup.where(status: "open")
+    end
+
+    def exceptions_trackable?
+      RailsPulse.configuration.track_exceptions && RailsPulse::ExceptionGroup.table_exists?
+    rescue ActiveRecord::ActiveRecordError
+      false
+    end
 
     # Only scan what the host is actually tracking. Scanning jobs when job
     # tracking is off would produce findings for a table that stopped being
@@ -115,6 +147,10 @@ module RailsPulse
     def severity_for(comparison)
       return "critical" if comparison.metric == :error_rate &&
         comparison.current_value >= Dashboard::Concerns::ThresholdConstants::CRITICAL_ERROR_RATE
+
+      if comparison.metric == :volume
+        return comparison.current_value >= RailsPulse.configuration.exception_thresholds[:critical] ? "critical" : "warning"
+      end
 
       threshold = critical_threshold_for(comparison.subject.type)
       return "critical" if threshold && comparison.current_value >= threshold

--- a/app/services/rails_pulse/operations/change_point.rb
+++ b/app/services/rails_pulse/operations/change_point.rb
@@ -86,8 +86,8 @@ module RailsPulse
         Result.new(
           at:           after.first.period_start,
           granularity:  series.period_type,
-          before_value: Metric.combine(before.map { |p| [ p.value, p.count ] }),
-          after_value:  Metric.combine(after.map { |p| [ p.value, p.count ] }),
+          before_value: Metric.combine(before.map { |p| [ p.value, p.count ] }, metric),
+          after_value:  Metric.combine(after.map { |p| [ p.value, p.count ] }, metric),
           before_count: before.sum(&:count),
           after_count:  after.sum(&:count)
         )
@@ -126,8 +126,8 @@ module RailsPulse
         best_gap   = 0.0
 
         (MIN_PERIODS_PER_SIDE..(points.size - MIN_PERIODS_PER_SIDE)).each do |index|
-          before = Metric.combine(points[0...index].map { |p| [ p.value, p.count ] })
-          after  = Metric.combine(points[index..].map  { |p| [ p.value, p.count ] })
+          before = Metric.combine(points[0...index].map { |p| [ p.value, p.count ] }, series.metric)
+          after  = Metric.combine(points[index..].map  { |p| [ p.value, p.count ] }, series.metric)
           next if before.nil? || after.nil?
 
           gap = (after - before).abs

--- a/app/services/rails_pulse/operations/comparison.rb
+++ b/app/services/rails_pulse/operations/comparison.rb
@@ -80,7 +80,11 @@ module RailsPulse
         return false unless Metric.higher_is_worse?(metric)
 
         thresholds = RailsPulse.configuration.regression_thresholds
-        floor      = metric == :error_rate ? thresholds[:min_delta_rate] : thresholds[:min_delta_ms]
+        floor      = case metric
+        when :error_rate then thresholds[:min_delta_rate]
+        when :volume     then thresholds[:min_delta_count]
+        else thresholds[:min_delta_ms]
+        end
 
         ratio >= thresholds[:ratio] && delta >= floor
       end
@@ -119,7 +123,11 @@ module RailsPulse
       private
 
       def format_value(value)
-        metric == :error_rate ? "#{value.round(2)}%" : "#{value.round(0).to_i}ms"
+        case metric
+        when :error_rate then "#{value.round(2)}%"
+        when :volume     then value.round(1).to_s
+        else "#{value.round(0).to_i}ms"
+        end
       end
     end
   end

--- a/app/services/rails_pulse/operations/metric.rb
+++ b/app/services/rails_pulse/operations/metric.rb
@@ -16,7 +16,15 @@ module RailsPulse
         avg: "avg_duration"
       }.freeze
 
-      SUPPORTED = (DURATION_COLUMNS.keys + [ :error_rate ]).freeze
+      SUPPORTED = (DURATION_COLUMNS.keys + [ :error_rate, :volume ]).freeze
+
+      # Duration and rate metrics are traffic-weighted; volume is not. Weighting
+      # a count by itself would square it — the right comparison for "how often
+      # did this happen?" is the mean per period, so a one-day window and a
+      # 28-day baseline are measured on the same scale.
+      def self.weighted?(metric)
+        metric.to_sym != :volume
+      end
 
       # Higher is worse for every metric currently supported, but stating it
       # explicitly keeps the comparison code from assuming it forever.
@@ -31,14 +39,20 @@ module RailsPulse
       end
 
       def self.unit(metric)
-        metric.to_sym == :error_rate ? "%" : "ms"
+        case metric.to_sym
+        when :error_rate then "%"
+        when :volume     then ""
+        else "ms"
+        end
       end
 
       # SQL that reduces a set of summary rows to a single value for this metric.
       # NULLIF guards the zero-count case rather than letting the database raise
       # or return a division artifact.
       def self.aggregate_sql(metric)
-        if metric.to_sym == :error_rate
+        if metric.to_sym == :volume
+          "AVG(rails_pulse_summaries.count)"
+        elsif metric.to_sym == :error_rate
           "SUM(rails_pulse_summaries.error_count) * 100.0 / " \
             "NULLIF(SUM(rails_pulse_summaries.count), 0)"
         else
@@ -51,7 +65,13 @@ module RailsPulse
       # Reduces an already-loaded set of [value, count] pairs the same way
       # aggregate_sql would. Used by change-point detection, which needs the
       # per-period series in memory anyway and should not round-trip per split.
-      def self.combine(pairs)
+      def self.combine(pairs, metric = :p95)
+        return nil if pairs.empty?
+
+        unless weighted?(metric)
+          return pairs.sum { |(value, _count)| value.to_f } / pairs.size
+        end
+
         total_count = pairs.sum { |(_value, count)| count.to_i }
         return nil if total_count.zero?
 

--- a/app/services/rails_pulse/operations/series.rb
+++ b/app/services/rails_pulse/operations/series.rb
@@ -39,6 +39,7 @@ module RailsPulse
         when :p95 then p95
         when :p99 then p99
         when :avg then avg
+        when :volume then count
         when :error_rate
           count.to_i.zero? ? nil : (error_count.to_i * 100.0 / count.to_i)
         end
@@ -69,7 +70,7 @@ module RailsPulse
 
       # The traffic-weighted value across every period in the series.
       def value
-        @value ||= Metric.combine(points.map { |point| [ point.value, point.count ] })
+        @value ||= Metric.combine(points.map { |point| [ point.value, point.count ] }, metric)
       end
 
       def first_period_start

--- a/app/services/rails_pulse/operations/subject.rb
+++ b/app/services/rails_pulse/operations/subject.rb
@@ -9,11 +9,20 @@ module RailsPulse
     # summaries are stored. It is the one place that knows about the
     # summarizable_id = 0 convention used for the overall request rollup.
     class Subject
-      SUPPORTED_TYPES = %w[RailsPulse::Route RailsPulse::Query RailsPulse::Job RailsPulse::Request].freeze
+      SUPPORTED_TYPES = %w[
+        RailsPulse::Route
+        RailsPulse::Query
+        RailsPulse::Job
+        RailsPulse::Request
+        RailsPulse::ExceptionGroup
+      ].freeze
 
       # The overall-request rollup is stored with a sentinel id rather than a
       # real record, so it needs its own constant.
       OVERALL_REQUESTS_ID = 0
+
+      # Exception summaries use the same sentinel for their all-groups rollup.
+      OVERALL_ROLLUP_ID = 0
 
       attr_reader :type, :id, :record
 
@@ -26,6 +35,10 @@ module RailsPulse
 
         if subject == :requests
           return new(type: "RailsPulse::Request", id: OVERALL_REQUESTS_ID, record: nil)
+        end
+
+        if subject == :exceptions
+          return new(type: "RailsPulse::ExceptionGroup", id: OVERALL_ROLLUP_ID, record: nil)
         end
 
         type = subject.class.name
@@ -53,14 +66,20 @@ module RailsPulse
         type == "RailsPulse::Request" && id == OVERALL_REQUESTS_ID
       end
 
+      def overall_exceptions?
+        type == "RailsPulse::ExceptionGroup" && id == OVERALL_ROLLUP_ID
+      end
+
       # Short human label, used in finding messages and API output.
       def label
         return "All requests" if overall_requests?
+        return "All exceptions" if overall_exceptions?
 
         case type
         when "RailsPulse::Route" then record&.path
         when "RailsPulse::Query" then record&.normalized_sql
         when "RailsPulse::Job"   then record&.name
+        when "RailsPulse::ExceptionGroup" then record&.exception_class
         end.presence || "#{type.demodulize} ##{id}"
       end
 

--- a/app/services/rails_pulse/summary_service.rb
+++ b/app/services/rails_pulse/summary_service.rb
@@ -17,6 +17,7 @@ module RailsPulse
         aggregate_routes    # Per-route metrics
         aggregate_queries   # Per-query metrics
         aggregate_jobs      # Per-job metrics
+        aggregate_exceptions # Per-exception-group frequency
       end
 
       RailsPulse.logger.info "Completed #{period_type} summary"
@@ -111,6 +112,50 @@ module RailsPulse
 
         summary.save!
       end
+    end
+
+    # Exception frequency, per group and overall.
+    #
+    # ExceptionGroup#occurrence_count is a lifetime counter and occurrence rows
+    # are pruned by retention, so without this there is no way to ask how often
+    # something happened last week — the history is gone as soon as cleanup
+    # runs. Only `count` is meaningful here; the duration columns stay null
+    # because an exception has no duration.
+    def aggregate_exceptions
+      return unless RailsPulse.configuration.track_exceptions
+      return unless ExceptionOccurrence.table_exists?
+
+      counts = ExceptionOccurrence
+        .where(occurred_at: start_time...end_time)
+        .group(:exception_group_id)
+        .count
+
+      return if counts.empty?
+
+      counts.each do |group_id, occurrences|
+        upsert_exception_summary(group_id, occurrences)
+      end
+
+      # A rollup across every group, so the dashboard can chart total exception
+      # volume without loading one series per group.
+      upsert_exception_summary(0, counts.values.sum)
+    rescue ActiveRecord::ActiveRecordError => e
+      # Exceptions are the newest summarizable and the only optional one. A
+      # failure here must not lose the route, query and job summaries that were
+      # written in the same transaction.
+      RailsPulse.logger.error "Exception summary skipped: #{e.message}"
+    end
+
+    def upsert_exception_summary(group_id, occurrences)
+      summary = Summary.find_or_initialize_by(
+        summarizable_type: "RailsPulse::ExceptionGroup",
+        summarizable_id: group_id,
+        period_type: period_type,
+        period_start: start_time
+      )
+
+      summary.assign_attributes(period_end: end_time, count: occurrences)
+      summary.save!
     end
 
     def aggregate_queries

--- a/app/views/rails_pulse/exceptions/_metric_cards.html.erb
+++ b/app/views/rails_pulse/exceptions/_metric_cards.html.erb
@@ -1,0 +1,5 @@
+<% metric_cards = [
+  @total_occurrences_metric_card,
+  @open_groups_metric_card
+].compact %>
+<%= render "rails_pulse/components/metric_strip", metrics_data: metric_cards %>

--- a/app/views/rails_pulse/exceptions/index.html.erb
+++ b/app/views/rails_pulse/exceptions/index.html.erb
@@ -1,5 +1,29 @@
 <%= render 'rails_pulse/components/page_header' %>
 
+<%= render 'rails_pulse/exceptions/metric_cards' %>
+
+<%= render 'rails_pulse/components/panel', {
+  title: 'Exception Frequency',
+  card_classes: 'b-full',
+  help_heading: 'Exception Frequency',
+  help_text: 'How often exceptions were raised over the selected period, across every group. Read from retained summaries rather than individual occurrence records, so the history stays accurate after cleanup has pruned old occurrences.'
+} do %>
+  <% if @occurrence_volume_chart %>
+    <div class="chart-container">
+      <%= render_stimulus_chart(
+        @occurrence_volume_chart,
+        type: "bar",
+        id: "exception_occurrence_volume_chart",
+        height: "220px"
+      ) %>
+    </div>
+  <% else %>
+    <%= render 'rails_pulse/components/empty_state',
+        title: 'No exception activity in this period.',
+        description: 'Frequency appears here once exceptions have been recorded and summarized.' %>
+  <% end %>
+<% end %>
+
 <%= render 'rails_pulse/components/panel', title: 'Exceptions' do %>
   <%= search_form_for @ransack_query, url: exceptions_path, class: "filter-bar" do |form| %>
     <div class="filter-bar__form">

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,117 +3,22 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "3d4cff0f317df7445891a1fc467912f3ad09e869da9b3e8433d5897354f5d849",
+      "fingerprint": "1f5708c3c390b8eca34ed8f3dcabbf5f79f266bca195c856dc816168f1b9ff10",
       "check_name": "SQL",
       "message": "Possible SQL injection",
-      "file": "app/models/rails_pulse/request.rb",
-      "line": 40,
+      "file": "app/models/rails_pulse/exceptions/cards/total_occurrences.rb",
+      "line": 27,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "Arel.sql(\"FLOOR(#{parent.table[:status].name} / 100)\")",
+      "code": "RailsPulse::Summary.overall_exceptions.where(:period_type => (@period_type), :period_start => ((range_start..now))).select(\"SUM(rails_pulse_summaries.count) AS total_count\", \"SUM(CASE WHEN rails_pulse_summaries.period_start >= #{quote(current_window_start)} THEN rails_pulse_summaries.count ELSE 0 END) AS current_count\", \"SUM(CASE WHEN rails_pulse_summaries.period_start >= #{quote(range_start)} AND rails_pulse_summaries.period_start < #{quote(current_window_start)} THEN rails_pulse_summaries.count ELSE 0 END) AS previous_count\")",
       "render_path": null,
       "location": {
         "type": "method",
-        "class": "Request",
-        "method": null
+        "class": "RailsPulse::Exceptions::Cards::TotalOccurrences",
+        "method": "to_metric_card"
       },
-      "user_input": "parent.table[:status].name",
+      "user_input": "quote(current_window_start)",
       "confidence": "Medium",
-      "cwe_id": [
-        89
-      ],
-      "note": "Reviewed: Using Arel.sql with column name from ActiveRecord table definition - safe, not user input"
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "dc13170579f824326ffcaf309858f90fc807c7bdc4bfe41df3bb5d2b8f719a12",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/models/rails_pulse/request.rb",
-      "line": 54,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "Arel.sql with configuration thresholds",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Request",
-        "method": null
-      },
-      "user_input": "((RailsPulse.configuration rescue nil).request_thresholds or { :slow => 500, :very_slow => 1000, :critical => 2000 })[:slow]",
-      "confidence": "Medium",
-      "cwe_id": [
-        89
-      ],
-      "note": "Reviewed: Using Arel.sql with configuration values from RailsPulse.configuration - safe, not user input"
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "3c816cd9f565d6592595f5566cbd9d9a19ecb51ad704477f01a9bf2b4c1f29fb",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/services/rails_pulse/analysis/explain_plan_analyzer.rb",
-      "line": 191,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "RailsPulse::ApplicationRecord.connection.execute(\"EXPLAIN (ANALYZE, BUFFERS) #{sql}\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "RailsPulse::Analysis::ExplainPlanAnalyzer",
-        "method": "execute_postgres_explain"
-      },
-      "user_input": "sql",
-      "confidence": "Medium",
-      "cwe_id": [
-        89
-      ],
-      "note": "Reviewed: EXPLAIN (without ANALYZE) is planner-only on all adapters. Only SELECT/WITH statements are passed — non-SELECT verbs are rejected by SAFE_VERB check."
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "a57a1c949d21de15d6b48e52bfc3077e3177a13ba1d703ddf48e241fb4e81c6e",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/services/rails_pulse/analysis/explain_plan_analyzer.rb",
-      "line": 196,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "RailsPulse::ApplicationRecord.connection.execute(\"EXPLAIN #{sql}\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "RailsPulse::Analysis::ExplainPlanAnalyzer",
-        "method": "execute_mysql_explain"
-      },
-      "user_input": "sql",
-      "confidence": "Medium",
-      "cwe_id": [
-        89
-      ],
-      "note": "Reviewed: EXPLAIN is planner-only on all adapters. Only SELECT/WITH statements are passed — non-SELECT verbs are rejected by SAFE_VERB check."
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "85c09ca9672d132fb206d0371e20087deaf381d89733f73d647129878b89f374",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/services/rails_pulse/analysis/explain_plan_analyzer.rb",
-      "line": 201,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "RailsPulse::ApplicationRecord.connection.execute(\"EXPLAIN QUERY PLAN #{sql}\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "RailsPulse::Analysis::ExplainPlanAnalyzer",
-        "method": "execute_sqlite_explain"
-      },
-      "user_input": "sql",
-      "confidence": "Medium",
-      "cwe_id": [
-        89
-      ],
-      "note": "Reviewed: EXPLAIN QUERY PLAN is planner-only on SQLite. Only SELECT/WITH statements are passed — non-SELECT verbs are rejected by SAFE_VERB check."
+      "note": "Reviewed: connection.quote() with internally computed Time objects (current_window_start / range_start), never user input. Same pattern as the jobs cards. The only interpolations are quoted timestamps; the period_type and period_start filters are bound parameters."
     },
     {
       "warning_type": "SQL Injection",
@@ -183,6 +88,121 @@
         89
       ],
       "note": "Reviewed: connection.quote() with internally computed Time objects (current_window_start, range_start) - safe, not user input. Used in SELECT CASE expressions where ? placeholders are not supported."
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "3d4cff0f317df7445891a1fc467912f3ad09e869da9b3e8433d5897354f5d849",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/models/rails_pulse/request.rb",
+      "line": 40,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "Arel.sql(\"FLOOR(#{parent.table[:status].name} / 100)\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Request",
+        "method": null
+      },
+      "user_input": "parent.table[:status].name",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "note": "Reviewed: Using Arel.sql with column name from ActiveRecord table definition - safe, not user input"
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "dc13170579f824326ffcaf309858f90fc807c7bdc4bfe41df3bb5d2b8f719a12",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/models/rails_pulse/request.rb",
+      "line": 54,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "Arel.sql with configuration thresholds",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Request",
+        "method": null
+      },
+      "user_input": "((RailsPulse.configuration rescue nil).request_thresholds or { :slow => 500, :very_slow => 1000, :critical => 2000 })[:slow]",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "note": "Reviewed: Using Arel.sql with configuration values from RailsPulse.configuration - safe, not user input"
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "3c816cd9f565d6592595f5566cbd9d9a19ecb51ad704477f01a9bf2b4c1f29fb",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/services/rails_pulse/analysis/explain_plan_analyzer.rb",
+      "line": 191,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "RailsPulse::ApplicationRecord.connection.execute(\"EXPLAIN (ANALYZE, BUFFERS) #{sql}\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "RailsPulse::Analysis::ExplainPlanAnalyzer",
+        "method": "execute_postgres_explain"
+      },
+      "user_input": "sql",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "note": "Reviewed: EXPLAIN (without ANALYZE) is planner-only on all adapters. Only SELECT/WITH statements are passed \u2014 non-SELECT verbs are rejected by SAFE_VERB check."
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "85c09ca9672d132fb206d0371e20087deaf381d89733f73d647129878b89f374",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/services/rails_pulse/analysis/explain_plan_analyzer.rb",
+      "line": 201,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "RailsPulse::ApplicationRecord.connection.execute(\"EXPLAIN QUERY PLAN #{sql}\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "RailsPulse::Analysis::ExplainPlanAnalyzer",
+        "method": "execute_sqlite_explain"
+      },
+      "user_input": "sql",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "note": "Reviewed: EXPLAIN QUERY PLAN is planner-only on SQLite. Only SELECT/WITH statements are passed \u2014 non-SELECT verbs are rejected by SAFE_VERB check."
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "a57a1c949d21de15d6b48e52bfc3077e3177a13ba1d703ddf48e241fb4e81c6e",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/services/rails_pulse/analysis/explain_plan_analyzer.rb",
+      "line": 196,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "RailsPulse::ApplicationRecord.connection.execute(\"EXPLAIN #{sql}\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "RailsPulse::Analysis::ExplainPlanAnalyzer",
+        "method": "execute_mysql_explain"
+      },
+      "user_input": "sql",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "note": "Reviewed: EXPLAIN is planner-only on all adapters. Only SELECT/WITH statements are passed \u2014 non-SELECT verbs are rejected by SAFE_VERB check."
     }
   ],
   "updated": "2026-04-14 21:59:41 +0700",

--- a/lib/generators/rails_pulse/templates/rails_pulse.rb
+++ b/lib/generators/rails_pulse/templates/rails_pulse.rb
@@ -369,6 +369,7 @@ RailsPulse.configure do |config|
   #   ratio:                1.5,   # 50% worse than baseline
   #   min_delta_ms:         50.0,  # ...and at least 50ms worse
   #   min_delta_rate:       1.0,   # ...or 1 percentage point, for error rates
+  #   min_delta_count:      5.0,   # ...or 5 more occurrences a day, for exception volume
   #   min_samples:          100,   # minimum observations on each side
   #   min_baseline_periods: 3      # minimum days of history before comparing
   # }

--- a/lib/rails_pulse/configuration.rb
+++ b/lib/rails_pulse/configuration.rb
@@ -48,6 +48,7 @@ module RailsPulse
                 :request_thresholds,
                 :query_thresholds,
                 :job_thresholds,
+                :exception_thresholds,
                 :max_table_records,
                 :regression_thresholds
 
@@ -57,6 +58,9 @@ module RailsPulse
       @request_thresholds = { slow: 700, very_slow: 2000, critical: 4000 }
       @query_thresholds = { slow: 100, very_slow: 500, critical: 1000 }
       @job_thresholds = { slow: 5_000, very_slow: 30_000, critical: 60_000 }
+      # Exception thresholds are occurrence counts over the dashboard period,
+      # not durations — an exception has no duration.
+      @exception_thresholds = { warning: 10, critical: 100 }
       @ignored_routes = []
       @ignored_requests = []
       @ignored_queries = []
@@ -137,6 +141,7 @@ module RailsPulse
         ratio:                1.5,
         min_delta_ms:         50.0,
         min_delta_rate:       1.0,
+        min_delta_count:      5.0,
         min_samples:          100,
         min_baseline_periods: 3
       }
@@ -227,6 +232,7 @@ module RailsPulse
       validate_threshold_hash!(@request_thresholds, "request_thresholds")
       validate_threshold_hash!(@query_thresholds, "query_thresholds")
       validate_threshold_hash!(@job_thresholds, "job_thresholds")
+      validate_threshold_hash!(@exception_thresholds, "exception_thresholds")
     end
 
     def validate_retention_settings!
@@ -262,7 +268,7 @@ module RailsPulse
         raise ArgumentError, "regression_thresholds must be a hash, got #{@regression_thresholds.class}"
       end
 
-      %i[ratio min_delta_ms min_delta_rate min_samples min_baseline_periods].each do |key|
+      %i[ratio min_delta_ms min_delta_rate min_delta_count min_samples min_baseline_periods].each do |key|
         value = @regression_thresholds[key]
         unless value.is_a?(Numeric) && value > 0
           raise ArgumentError, "regression_thresholds[:#{key}] must be a positive number, got #{value.inspect}"

--- a/test/controllers/rails_pulse/exceptions_controller_test.rb
+++ b/test/controllers/rails_pulse/exceptions_controller_test.rb
@@ -35,6 +35,31 @@ class RailsPulse::ExceptionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "index assigns the frequency chart and metric cards" do
+    get rails_pulse.exceptions_path
+
+    assert_response :success
+    assert_not_nil assigns(:total_occurrences_metric_card)
+    assert_not_nil assigns(:open_groups_metric_card)
+  end
+
+  test "index assigns a time range" do
+    get rails_pulse.exceptions_path
+
+    assert_not_nil assigns(:start_time)
+    assert_not_nil assigns(:end_time)
+    assert_includes %w[hour day], assigns(:period_type)
+  end
+
+  test "index renders without a frequency chart when nothing is summarized" do
+    RailsPulse::Summary.delete_all
+
+    get rails_pulse.exceptions_path
+
+    assert_response :success
+    assert_nil assigns(:occurrence_volume_chart)
+  end
+
   test "index assigns table_data" do
     get rails_pulse.exceptions_path
 

--- a/test/models/rails_pulse/dashboard/exception_health_test.rb
+++ b/test/models/rails_pulse/dashboard/exception_health_test.rb
@@ -1,0 +1,162 @@
+require "test_helper"
+
+module RailsPulse
+  module Dashboard
+    # Before this, HealthSummary and NeedsAttention contained zero references to
+    # exceptions — the two surfaces that define "where should I look" were blind
+    # to errors entirely.
+    class ExceptionHealthTest < ActiveSupport::TestCase
+      fixtures :rails_pulse_exception_groups
+
+      def setup
+        @now = Time.current
+        travel_to @now
+        RailsPulse::Summary.delete_all
+        RailsPulse::Finding.delete_all
+        RailsPulse::Job.update_all(runs_count: 0, failures_count: 0, p95_duration: nil)
+        @original_tracking = RailsPulse.configuration.track_exceptions
+        RailsPulse.configuration.track_exceptions = true
+      end
+
+      def teardown
+        RailsPulse.configuration.track_exceptions = @original_tracking
+        travel_back
+      end
+
+      def exception_summary(group_id, count:, days_ago: 1)
+        period_start = (@now - days_ago.days).beginning_of_day
+
+        RailsPulse::Summary.create!(
+          summarizable_type: "RailsPulse::ExceptionGroup",
+          summarizable_id:   group_id,
+          period_type:       "day",
+          period_start:      period_start,
+          period_end:        period_start.end_of_day,
+          count:             count
+        )
+      end
+
+      def open_groups
+        RailsPulse::ExceptionGroup.where(status: "open")
+      end
+
+      # Health Summary Tests
+
+      test "health summary reports exception counts" do
+        health = HealthSummary.new.to_health_data
+
+        assert_not_nil health[:exceptions]
+        assert_equal open_groups.count, health[:exceptions].values.sum
+      end
+
+      test "a group above the critical threshold counts as critical" do
+        exception_summary(open_groups.first.id, count: 500)
+
+        health = HealthSummary.new.to_health_data
+
+        assert_equal 1, health[:exceptions][:critical]
+      end
+
+      test "a group above the warning threshold counts as slow" do
+        exception_summary(open_groups.first.id, count: 25)
+
+        health = HealthSummary.new.to_health_data
+
+        assert_equal 1, health[:exceptions][:slow]
+        assert_equal 0, health[:exceptions][:critical]
+      end
+
+      test "a group firing at all is not counted as healthy" do
+        # One occurrence is below the warning threshold but is still not health.
+        exception_summary(open_groups.first.id, count: 1)
+
+        health = HealthSummary.new.to_health_data
+
+        assert_equal 1, health[:exceptions][:slow]
+      end
+
+      test "a silent open group counts as healthy" do
+        health = HealthSummary.new.to_health_data
+
+        assert_equal open_groups.count, health[:exceptions][:healthy]
+      end
+
+      test "health summary omits exceptions when tracking is disabled" do
+        RailsPulse.configuration.track_exceptions = false
+
+        assert_nil HealthSummary.new.to_health_data[:exceptions]
+      end
+
+      test "lifetime occurrence_count does not drive health" do
+        # The fixture group carries occurrence_count 5 from its lifetime, but no
+        # summary rows in the period: it must read as healthy today.
+        group = rails_pulse_exception_groups(:record_not_found)
+
+        assert_operator group.occurrence_count, :>, 0
+        health = HealthSummary.new.to_health_data
+
+        assert_equal 0, health[:exceptions][:critical]
+      end
+
+      # Needs Attention Tests
+
+      test "surfaces an exception group above the warning threshold" do
+        group = rails_pulse_exception_groups(:record_not_found)
+        exception_summary(group.id, count: 25)
+
+        result = NeedsAttention.new.to_attention_data
+        item = (result[:critical] + result[:warning]).find { |i| i[:type] == "EXCEPTION" }
+
+        assert_not_nil item
+        assert_equal "ActiveRecord::RecordNotFound", item[:name]
+        assert_includes item[:reason], "25 occurrences"
+      end
+
+      test "does not surface a group below the warning threshold" do
+        exception_summary(open_groups.first.id, count: 2)
+
+        result = NeedsAttention.new.to_attention_data
+        items = (result[:critical] + result[:warning]).select { |i| i[:type] == "EXCEPTION" }
+
+        assert_empty items
+      end
+
+      test "a group above the critical threshold is critical" do
+        exception_summary(open_groups.first.id, count: 500)
+
+        result = NeedsAttention.new.to_attention_data
+
+        assert_equal 1, result[:critical].count { |i| i[:type] == "EXCEPTION" }
+      end
+
+      test "does not surface a resolved group" do
+        resolved = rails_pulse_exception_groups(:resolved_group)
+        exception_summary(resolved.id, count: 500)
+
+        result = NeedsAttention.new.to_attention_data
+        items = (result[:critical] + result[:warning]).select { |i| i[:type] == "EXCEPTION" }
+
+        assert_empty items
+      end
+
+      test "does not surface exceptions when tracking is disabled" do
+        RailsPulse.configuration.track_exceptions = false
+        exception_summary(open_groups.first.id, count: 500)
+
+        result = NeedsAttention.new.to_attention_data
+        items = (result[:critical] + result[:warning]).select { |i| i[:type] == "EXCEPTION" }
+
+        assert_empty items
+      end
+
+      test "the all-groups rollup is not reported as a group" do
+        exception_summary(0, count: 500)
+
+        result = NeedsAttention.new.to_attention_data
+        items = (result[:critical] + result[:warning]).select { |i| i[:type] == "EXCEPTION" }
+
+        assert_empty items
+      end
+    end
+  end
+end

--- a/test/services/rails_pulse/exception_summary_test.rb
+++ b/test/services/rails_pulse/exception_summary_test.rb
@@ -1,0 +1,165 @@
+require "test_helper"
+
+module RailsPulse
+  # Exception frequency has to survive retention. ExceptionGroup#occurrence_count
+  # is a lifetime counter and occurrence rows are pruned, so without summaries
+  # there is no way to ask how often something happened last week.
+  class ExceptionSummaryTest < ActiveSupport::TestCase
+    fixtures :rails_pulse_exception_groups
+
+    def setup
+      @group = rails_pulse_exception_groups(:record_not_found)
+      @hour  = Time.utc(2026, 6, 15, 10, 0, 0)
+      travel_to @hour + 30.minutes
+      RailsPulse::Summary.delete_all
+      RailsPulse::ExceptionOccurrence.delete_all
+      @original_tracking = RailsPulse.configuration.track_exceptions
+      RailsPulse.configuration.track_exceptions = true
+    end
+
+    def teardown
+      RailsPulse.configuration.track_exceptions = @original_tracking
+      travel_back
+    end
+
+    def occurrence_at(time, group: nil)
+      RailsPulse::ExceptionOccurrence.create!(
+        exception_group: group || @group,
+        exception_class: (group || @group).exception_class,
+        message:         "boom",
+        occurred_at:     time
+      )
+    end
+
+    def summarize
+      SummaryService.new("hour", @hour).perform
+    end
+
+    def group_summary(group_id)
+      RailsPulse::Summary.find_by(
+        summarizable_type: "RailsPulse::ExceptionGroup",
+        summarizable_id:   group_id,
+        period_type:       "hour",
+        period_start:      @hour
+      )
+    end
+
+    # Structure Tests
+
+    test "records a per-group count for the period" do
+      3.times { occurrence_at(@hour + 5.minutes) }
+
+      summarize
+
+      assert_equal 3, group_summary(@group.id).count
+    end
+
+    test "records an all-groups rollup" do
+      other = rails_pulse_exception_groups(:zero_division)
+      2.times { occurrence_at(@hour + 5.minutes) }
+      3.times { occurrence_at(@hour + 6.minutes, group: other) }
+
+      summarize
+
+      assert_equal 5, group_summary(0).count
+    end
+
+    test "leaves duration columns null because exceptions have no duration" do
+      occurrence_at(@hour + 5.minutes)
+
+      summarize
+      summary = group_summary(@group.id)
+
+      assert_nil summary.p95_duration
+      assert_nil summary.avg_duration
+    end
+
+    test "sets the period boundaries" do
+      occurrence_at(@hour + 5.minutes)
+
+      summarize
+      summary = group_summary(@group.id)
+
+      assert_equal @hour, summary.period_start
+      assert_equal @hour.end_of_hour.change(usec: 0), summary.period_end.change(usec: 0)
+    end
+
+    # Scoping Tests
+
+    test "counts only occurrences inside the period" do
+      occurrence_at(@hour - 10.minutes)
+      occurrence_at(@hour + 5.minutes)
+      occurrence_at(@hour + 2.hours)
+
+      summarize
+
+      assert_equal 1, group_summary(@group.id).count
+    end
+
+    test "re-running the summary replaces rather than doubles the count" do
+      2.times { occurrence_at(@hour + 5.minutes) }
+
+      summarize
+      summarize
+
+      assert_equal 2, group_summary(@group.id).count
+      assert_equal 1, RailsPulse::Summary.for_exceptions.where(summarizable_id: @group.id).count
+    end
+
+    # Configuration Tests
+
+    test "writes nothing when exception tracking is disabled" do
+      RailsPulse.configuration.track_exceptions = false
+      occurrence_at(@hour + 5.minutes)
+
+      summarize
+
+      assert_empty RailsPulse::Summary.for_exceptions
+    end
+
+    # Edge Cases
+
+    test "writes nothing when no exceptions occurred" do
+      summarize
+
+      assert_empty RailsPulse::Summary.for_exceptions
+    end
+
+    test "route and query summaries still run when exceptions are present" do
+      occurrence_at(@hour + 5.minutes)
+
+      # The exception aggregation must not raise in a way that rolls back the
+      # rest of the transaction.
+      assert_nothing_raised { summarize }
+    end
+
+    # Scope Tests
+
+    test "for_exceptions returns only exception summaries" do
+      occurrence_at(@hour + 5.minutes)
+      summarize
+
+      types = RailsPulse::Summary.for_exceptions.pluck(:summarizable_type).uniq
+
+      assert_equal [ "RailsPulse::ExceptionGroup" ], types
+    end
+
+    test "overall_exceptions returns only the rollup row" do
+      occurrence_at(@hour + 5.minutes)
+      summarize
+
+      assert_equal [ 0 ], RailsPulse::Summary.overall_exceptions.pluck(:summarizable_id).uniq
+    end
+
+    test "exception summaries pass through the tag filter" do
+      occurrence_at(@hour + 5.minutes)
+      summarize
+
+      # Exception groups have no tags column, so disabling every tag must not
+      # hide them the way it would hide an untagged route.
+      filtered = RailsPulse::Summary.with_tag_filters([ "critical" ], false).for_exceptions
+
+      assert_operator filtered.count, :>, 0
+    end
+  end
+end


### PR DESCRIPTION
**Step 3 of 4** in the OSS V1 track. Stacked on #208 → #207 — **base those first**, this targets `oss-v1/persisted-findings`.

## Why

The exception data model is the best-specified thing in the repo: three ADRs, a fingerprint scheme that survives refactors, lifecycle status, `preserve`, fifty backtrace frames, filtered params, `deploy_sha` captured because it can't be backfilled. What sits on top of it is a filterable list.

Two concrete consequences:

**`HealthSummary` and `NeedsAttention` contained zero references to exceptions.** The two surfaces that define "where should I look" were blind to errors entirely.

**There were no exception summaries.** `occurrence_count` is a lifetime counter, and occurrence rows are pruned by retention — so historical frequency was lost the moment cleanup ran. *"Which exceptions are increasing?"*, which the roadmap commits OSS to answering, was not computable from the schema.

## What this adds

**Summarization.** `ExceptionGroup` becomes a summarizable type. `SummaryService` writes a per-group count per period plus an all-groups rollup, so charting total volume is one query rather than one per group.

**No schema change** — the summaries table is already polymorphic and already has the `count` column this needs. Duration columns stay null because an exception has no duration.

**Dashboard integration.** `HealthSummary` gains exception counts; `NeedsAttention` surfaces groups above the configured thresholds.

**Frequency view.** The exceptions index gains occurrence and open-group metric cards plus a frequency chart.

**A `:volume` metric** in `Operations`, so frequency can be compared the way duration is — which `FindingDetector` picks up as `exception_frequency_regression`. That's what makes "which exceptions are increasing?" *answerable* rather than merely visible.

## Design decisions worth reviewing

**Health is classified by occurrences over the period, not by `occurrence_count`.** A group that fired ten thousand times last year and is silent now is not a critical problem today.

**A group firing at all counts as "slow", not "healthy".** An exception happening is not health — it's just not yet urgent. Pushback welcome; the alternative is a threshold below which errors read as green.

**Ignored groups are excluded from the attention list.** Marking a group ignored is the user saying "stop telling me about this", and the attention list is exactly where that has to be honoured. `FindingDetector` scans open groups only, for the same reason.

**Volume is the one metric that is not traffic-weighted.** Weighting a count by itself would square it. The right comparison for "how often did this happen?" is the mean per period, so a one-day window and a 28-day baseline are measured on the same scale.

**Exception aggregation is guarded so it cannot roll back the transaction.** Route, query and job summaries are written alongside it; exceptions are the newest summarizable and the only optional one, so they must not be able to take the others down.

**`with_tag_filters` needed a change.** It hardcoded three summarizable types in a raw SQL string. Exception groups have no `tags` column, so they pass through the way the overall request rollup does — otherwise every exception summary would be filtered out as untagged.

**The index lists groups, not aggregates,** so it doesn't use `ChartTableConcern` (same reasoning CLAUDE.md records for the requests index). It includes `TimeRangeConcern` for a consistent range.

## Config added

`exception_thresholds = { warning: 10, critical: 100 }` — occurrence counts over the dashboard period, not durations. `regression_thresholds[:min_delta_count] = 5.0` as the absolute floor for volume regressions.

⚠️ Both defaults are guesses that want a second opinion. 10 occurrences a day as "warning" will be far too noisy for a high-traffic app and about right for a small one.

## Tests

25 new tests (12 summarization, 13 dashboard) plus 3 new controller tests.

Full suite green: **3228 runs, 8790 assertions, 0 failures, 0 errors**, plus **22 migration tests**. RuboCop clean.

Covers per-group and rollup counts, period scoping, idempotent re-runs, tracking disabled, tag-filter passthrough, all four health classifications, lifetime-count independence, ignored/resolved exclusion, and the rollup row not being reported as a group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BaximWeiDUL64Mr5RXWi4n