### PR TITLE
Give findings somewhere to live, and make deployments browsable

### DIFF
--- a/app/controllers/rails_pulse/deployments_controller.rb
+++ b/app/controllers/rails_pulse/deployments_controller.rb
@@ -1,8 +1,23 @@
 module RailsPulse
   class DeploymentsController < ApplicationController
-    skip_before_action :authenticate_rails_pulse_user!
+    # The API actions authenticate by token so CI can post without a session;
+    # the browsable pages use the dashboard's own authentication like every
+    # other page. Keeping the skip scoped to create/finish means adding a UI
+    # does not widen the hole the 0.4.0 audit closed.
+    skip_before_action :authenticate_rails_pulse_user!, only: %i[create finish]
     skip_before_action :verify_authenticity_token, only: %i[create finish]
-    before_action :authenticate_deployment_request!
+    before_action :authenticate_deployment_request!, only: %i[create finish]
+
+    def index
+      @ransack_query = Deployment.ransack(params[:q] || {})
+      @ransack_query.sorts = "started_at desc" if @ransack_query.sorts.empty?
+      @pagination, @table_data = paginate(@ransack_query.result, limit: session_pagination_limit)
+    end
+
+    def show
+      @deployment = Deployment.find(params[:id])
+      @findings = related_findings(@deployment)
+    end
 
     def create
       deployment = RailsPulse::Deployment.new(
@@ -41,6 +56,19 @@ module RailsPulse
     end
 
     private
+
+    # Findings whose estimated change point sits close after this deployment.
+    # Derived rather than stored — see DeploymentCorrelator for why.
+    def related_findings(deployment)
+      window = DeploymentCorrelator::DEFAULT_WINDOW
+
+      candidates = RailsPulse::Finding
+        .where.not(changed_at: nil)
+        .where(changed_at: deployment.started_at..(deployment.started_at + DeploymentCorrelator::DAY_GRANULARITY_LOOKAHEAD + window))
+        .order(changed_at: :asc)
+
+      candidates.select { |finding| DeploymentCorrelator.for(finding)&.id == deployment.id }
+    end
 
     def authenticate_deployment_request!
       token = RailsPulse.configuration.deployment_api_token

--- a/app/controllers/rails_pulse/findings_controller.rb
+++ b/app/controllers/rails_pulse/findings_controller.rb
@@ -1,0 +1,61 @@
+module RailsPulse
+  # Findings are written by FindingDetector once a day. This is where they live
+  # — the surface that turns "we detected a regression" into something a person
+  # can read, act on, and dismiss.
+  class FindingsController < ApplicationController
+    before_action :set_finding, only: %i[show update]
+
+    def index
+      ransack_params = (params[:q] || {}).dup
+      apply_default_status_filter!(ransack_params)
+
+      @ransack_query = Finding.ransack(ransack_params)
+      @ransack_query.sorts = "last_detected_at desc" if @ransack_query.sorts.empty?
+
+      @pagination, @table_data = paginate(@ransack_query.result, limit: session_pagination_limit)
+      @deployments = DeploymentCorrelator.for_all(@table_data)
+      @counts = status_counts
+    end
+
+    def show
+      @deployment = DeploymentCorrelator.for(@finding)
+    end
+
+    # Acknowledge or reopen. Resolution is not a manual action: a finding is
+    # resolved when detection stops seeing it, so letting a user mark one
+    # resolved by hand would produce a row the next detection run immediately
+    # contradicts.
+    def update
+      case params[:status]
+      when "acknowledged"
+        @finding.update!(status: "acknowledged")
+        notice = "Finding acknowledged."
+      when "open"
+        @finding.update!(status: "open")
+        notice = "Finding reopened."
+      else
+        return redirect_to finding_path(@finding), alert: "Unknown action."
+      end
+
+      redirect_to finding_path(@finding), notice: notice
+    end
+
+    private
+
+    def set_finding
+      @finding = Finding.find(params[:id])
+    end
+
+    # Default to what is still live. A resolved finding is history, and the list
+    # is more useful as a description of the present.
+    def apply_default_status_filter!(ransack_params)
+      return if ransack_params.key?(:status_eq) || ransack_params.key?("status_eq")
+
+      ransack_params[:status_eq] = "open"
+    end
+
+    def status_counts
+      Finding.group(:status).count
+    end
+  end
+end

--- a/app/helpers/rails_pulse/application_helper.rb
+++ b/app/helpers/rails_pulse/application_helper.rb
@@ -4,6 +4,7 @@ module RailsPulse
     include BreadcrumbsHelper
     include ChartHelper
     include CspHelper
+    include FindingsHelper
     include FormattingHelper
     include FormHelper
     include IconHelper

--- a/app/helpers/rails_pulse/findings_helper.rb
+++ b/app/helpers/rails_pulse/findings_helper.rb
@@ -1,0 +1,32 @@
+module RailsPulse
+  module FindingsHelper
+    # Findings point at four different kinds of subject, and the overall request
+    # rollup points at none. Keeping the mapping here stops each view growing
+    # its own case statement.
+    def finding_subject_path(finding)
+      case finding.subject_type
+      when "RailsPulse::Route"          then route_path(finding.subject_id)
+      when "RailsPulse::Query"          then query_path(finding.subject_id)
+      when "RailsPulse::Job"            then job_path(finding.subject_id)
+      when "RailsPulse::ExceptionGroup" then exception_path(finding.subject_id)
+      end
+    end
+
+    def finding_metric_label(finding)
+      case finding.metric
+      when "error_rate" then "Error rate"
+      when "volume"     then "Frequency"
+      else finding.metric.upcase
+      end
+    end
+
+    # "220ms → 1420ms" split into its two halves for display.
+    def finding_baseline_display(finding)
+      finding.to_s.split(": ", 2).last.to_s.split(" → ").first
+    end
+
+    def finding_current_display(finding)
+      finding.to_s.split(" → ").last
+    end
+  end
+end

--- a/app/services/rails_pulse/deployment_correlator.rb
+++ b/app/services/rails_pulse/deployment_correlator.rb
@@ -1,0 +1,88 @@
+module RailsPulse
+  # Finds the deployment a regression most plausibly belongs to.
+  #
+  # Deliberately derived at read time rather than stored on the finding. A
+  # deployment is often recorded by CI moments after the code is live, and
+  # sometimes late or retroactively; correlating on read means a deployment
+  # recorded after detection still lines up, where a column written once would
+  # be permanently wrong. The inputs — the change point and the deployment
+  # timeline — are both already persisted, so nothing is lost by deriving it.
+  #
+  # This states adjacency, not causation. A deployment shortly before a
+  # regression is worth looking at; it is not proof, and the UI should not
+  # phrase it as one.
+  class DeploymentCorrelator
+    # How far before a change point a deployment can sit and still be considered
+    # related. Wide enough to absorb the lag between deploying and the metric
+    # moving, narrow enough that an unrelated deploy days earlier is not blamed.
+    DEFAULT_WINDOW = 6.hours
+
+    # A day-granularity change point could be anywhere in that day, so a
+    # deployment slightly after midnight on the identified day is still a
+    # candidate.
+    DAY_GRANULARITY_LOOKAHEAD = 1.day
+
+    def self.for(finding, window: DEFAULT_WINDOW)
+      new(finding, window: window).call
+    end
+
+    # Correlates a batch in one query rather than one per finding, for the index.
+    #
+    # @return [Hash{Integer => RailsPulse::Deployment}] keyed by finding id
+    def self.for_all(findings, window: DEFAULT_WINDOW)
+      findings = findings.select(&:change_point_known?)
+      return {} if findings.empty?
+
+      earliest = findings.map(&:changed_at).min - window
+      latest   = findings.map(&:changed_at).max + DAY_GRANULARITY_LOOKAHEAD
+
+      deployments = RailsPulse::Deployment
+        .where(started_at: earliest..latest)
+        .order(started_at: :asc)
+        .to_a
+
+      findings.each_with_object({}) do |finding, correlated|
+        match = new(finding, window: window, deployments: deployments).call
+        correlated[finding.id] = match if match
+      end
+    end
+
+    def initialize(finding, window: DEFAULT_WINDOW, deployments: nil)
+      @finding     = finding
+      @window      = window
+      @deployments = deployments
+    end
+
+    def call
+      return nil unless finding.change_point_known?
+
+      candidates.max_by(&:started_at)
+    end
+
+    private
+
+    attr_reader :finding, :window, :deployments
+
+    def candidates
+      range = search_range
+
+      if deployments
+        deployments.select { |deployment| range.cover?(deployment.started_at) }
+      else
+        RailsPulse::Deployment.where(started_at: range).to_a
+      end
+    end
+
+    # An hourly change point is accurate, so only look backwards. A daily one
+    # only identifies the day, so a deployment anywhere in that day qualifies.
+    def search_range
+      changed_at = finding.changed_at
+
+      if finding.hourly_change_point?
+        (changed_at - window)..changed_at
+      else
+        (changed_at - window)..(changed_at + DAY_GRANULARITY_LOOKAHEAD)
+      end
+    end
+  end
+end

--- a/app/views/layouts/rails_pulse/_menu_items.html.erb
+++ b/app/views/layouts/rails_pulse/_menu_items.html.erb
@@ -13,6 +13,11 @@
   <span class="overflow-ellipsis">Queries</span>
 <% end %>
 
+<%= link_to findings_path, class: 'btn sidebar-menu__button' do %>
+  <%= rails_pulse_icon "trending-up", width: "16" %>
+  <span class="overflow-ellipsis">Findings</span>
+<% end %>
+
 <% if RailsPulse.configuration.track_exceptions %>
   <%= link_to exceptions_path, class: 'btn sidebar-menu__button' do %>
     <%= rails_pulse_icon "alert-circle", width: "16" %>
@@ -25,6 +30,11 @@
     <%= rails_pulse_icon "zap", width: "16" %>
     <span class="overflow-ellipsis">Jobs</span>
   <% end %>
+<% end %>
+
+<%= link_to deployments_path, class: 'btn sidebar-menu__button' do %>
+  <%= rails_pulse_icon "rocket", width: "16" %>
+  <span class="overflow-ellipsis">Deployments</span>
 <% end %>
 
 <% RailsPulse.nav_items.each do |item| %>

--- a/app/views/rails_pulse/deployments/_table.html.erb
+++ b/app/views/rails_pulse/deployments/_table.html.erb
@@ -1,0 +1,27 @@
+<% columns = [
+  { field: :revision,    label: 'Revision',  cell_class: 'truncate-cell' },
+  { field: :started_at,  label: 'Started',   class: 'w-56' },
+  { field: :finished_at, label: 'Finished',  class: 'w-56' }
+] %>
+
+<table class="table table-fixed mbs-4">
+  <%= render "rails_pulse/components/table_head", columns: columns %>
+
+  <tbody>
+    <% @table_data.each do |deployment| %>
+      <tr>
+        <td class="truncate-cell">
+          <%= link_to deployment_path(deployment) do %>
+            <code><%= deployment.revision %></code>
+          <% end %>
+        </td>
+        <td class="whitespace-nowrap"><%= human_readable_occurred_at(deployment.started_at) %></td>
+        <td class="whitespace-nowrap">
+          <%= deployment.finished_at ? human_readable_occurred_at(deployment.finished_at) : content_tag(:span, "—", class: "text-subtle") %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= render "rails_pulse/components/table_pagination" %>

--- a/app/views/rails_pulse/deployments/index.html.erb
+++ b/app/views/rails_pulse/deployments/index.html.erb
@@ -1,0 +1,15 @@
+<%= render 'rails_pulse/components/page_header' %>
+
+<%= render 'rails_pulse/components/panel', {
+  title: 'Deployments',
+  help_heading: 'Deployments',
+  help_text: 'Deployments recorded by your CI/CD pipeline via the deployments API or the rails_pulse:record_deployment rake task. They appear as markers on charts and are correlated against detected regressions.'
+} do %>
+  <% if @table_data.any? %>
+    <%= render 'rails_pulse/deployments/table' %>
+  <% else %>
+    <%= render 'rails_pulse/components/empty_state',
+        title: 'No deployments recorded.',
+        description: 'Post to the deployments endpoint from your deploy pipeline, or run rails_pulse:record_deployment, and they will appear here.' %>
+  <% end %>
+<% end %>

--- a/app/views/rails_pulse/deployments/show.html.erb
+++ b/app/views/rails_pulse/deployments/show.html.erb
@@ -1,0 +1,52 @@
+<%= render 'rails_pulse/components/page_header' %>
+
+<%= render 'rails_pulse/components/panel', title: @deployment.revision do %>
+  <dl class="flex gap flex-wrap">
+    <div>
+      <dt class="text-subtle text-xs uppercase">Started</dt>
+      <dd class="font-semibold"><%= human_readable_occurred_at(@deployment.started_at) %></dd>
+    </div>
+    <div>
+      <dt class="text-subtle text-xs uppercase">Finished</dt>
+      <dd class="font-semibold">
+        <%= @deployment.finished_at ? human_readable_occurred_at(@deployment.finished_at) : "—" %>
+      </dd>
+    </div>
+  </dl>
+
+  <% if @deployment.metadata_hash.any? %>
+    <h3 class="font-semibold text-sm mbs-4 mbe-2">Metadata</h3>
+    <dl class="flex gap flex-wrap">
+      <% @deployment.metadata_hash.each do |key, value| %>
+        <div>
+          <dt class="text-subtle text-xs uppercase"><%= key %></dt>
+          <dd><%= value %></dd>
+        </div>
+      <% end %>
+    </dl>
+  <% end %>
+<% end %>
+
+<%= render 'rails_pulse/components/panel', {
+  title: 'Regressions near this deployment',
+  help_heading: 'Correlated Regressions',
+  help_text: 'Findings whose estimated change point falls shortly after this deployment. Adjacency is not causation — a deployment close to a regression is a place to look first, not an explanation.'
+} do %>
+  <% if @findings.any? %>
+    <ul class="flex flex-col gap-half mbs-2">
+      <% @findings.each do |finding| %>
+        <li class="text-sm">
+          <%= link_to finding.subject_label, finding_path(finding) %>
+          <span class="text-subtle">
+            — <%= finding_metric_label(finding) %>
+            <%= finding_baseline_display(finding) %> → <%= finding_current_display(finding) %>
+          </span>
+        </li>
+      <% end %>
+    </ul>
+  <% else %>
+    <p class="text-sm text-subtle mbs-2">
+      No detected regressions line up with this deployment.
+    </p>
+  <% end %>
+<% end %>

--- a/app/views/rails_pulse/findings/_severity_badge.html.erb
+++ b/app/views/rails_pulse/findings/_severity_badge.html.erb
@@ -1,0 +1,2 @@
+<% badge_class = finding.severity == "critical" ? "badge--negative" : "badge--secondary" %>
+<span class="badge <%= badge_class %>"><%= finding.severity.capitalize %></span>

--- a/app/views/rails_pulse/findings/_status_badge.html.erb
+++ b/app/views/rails_pulse/findings/_status_badge.html.erb
@@ -1,0 +1,6 @@
+<% badge_class = case finding.status
+  when "resolved"     then "badge--positive"
+  when "acknowledged" then "badge--secondary"
+  else                     "badge--negative"
+  end %>
+<span class="badge <%= badge_class %>"><%= finding.status.capitalize %></span>

--- a/app/views/rails_pulse/findings/_table.html.erb
+++ b/app/views/rails_pulse/findings/_table.html.erb
@@ -1,0 +1,53 @@
+<% columns = [
+  { field: :subject_type,     label: 'What',       cell_class: 'truncate-cell', sortable: false },
+  { field: :severity,         label: 'Severity',   class: 'w-28' },
+  { field: :status,           label: 'Status',     class: 'w-32' },
+  { field: :ratio,            label: 'Change',     class: 'w-32' },
+  { field: :changed_at,       label: 'Started',    class: 'w-48' },
+  { field: :last_detected_at, label: 'Last Seen',  class: 'w-48' }
+] %>
+
+<table class="table table-fixed mbs-4">
+  <%= render "rails_pulse/components/table_head", columns: columns %>
+
+  <tbody>
+    <% @table_data.each do |finding| %>
+      <tr>
+        <td class="truncate-cell">
+          <%= link_to finding.subject_label, finding_path(finding) %>
+          <div class="text-subtle text-xs truncate">
+            <%= finding_metric_label(finding) %>
+            <%= finding_baseline_display(finding) %> → <%= finding_current_display(finding) %>
+          </div>
+          <% if (deployment = @deployments[finding.id]) %>
+            <div class="text-subtle text-xs truncate">
+              near deploy <code><%= deployment.revision.first(12) %></code>
+            </div>
+          <% end %>
+        </td>
+        <td><%= render 'rails_pulse/findings/severity_badge', finding: finding %></td>
+        <td><%= render 'rails_pulse/findings/status_badge', finding: finding %></td>
+        <td class="whitespace-nowrap">
+          <% if finding.percent_change %>
+            +<%= number_with_delimiter(finding.percent_change.round(0).to_i) %>%
+          <% else %>
+            —
+          <% end %>
+        </td>
+        <td class="whitespace-nowrap">
+          <% if finding.change_point_known? %>
+            <%= human_readable_occurred_at(finding.changed_at) %>
+            <% unless finding.hourly_change_point? %>
+              <span class="text-subtle text-xs">(to the day)</span>
+            <% end %>
+          <% else %>
+            <span class="text-subtle">unknown</span>
+          <% end %>
+        </td>
+        <td class="whitespace-nowrap"><%= human_readable_occurred_at(finding.last_detected_at) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= render "rails_pulse/components/table_pagination" %>

--- a/app/views/rails_pulse/findings/index.html.erb
+++ b/app/views/rails_pulse/findings/index.html.erb
@@ -1,0 +1,42 @@
+<%= render 'rails_pulse/components/page_header' %>
+
+<%= render 'rails_pulse/components/panel', {
+  title: 'Findings',
+  help_heading: 'Findings',
+  help_text: 'Regressions detected by comparing each route, query, job and exception group against its own history. Unlike the threshold rules on the dashboard, a finding means something got worse — not that it is slow in absolute terms. Findings resolve themselves when detection stops seeing them.'
+} do %>
+  <%= search_form_for @ransack_query, url: findings_path, class: "filter-bar" do |form| %>
+    <div class="filter-bar__form">
+      <%= form.select :status_eq,
+        options_for_select(
+          [["All", ""]] + RailsPulse::Finding::STATUSES.map { |s| [s.capitalize, s] },
+          @ransack_query.status_eq
+        ),
+        {},
+        { class: "input" }
+      %>
+      <%= form.select :severity_eq,
+        options_for_select(
+          [["Any severity", ""]] + RailsPulse::Finding::SEVERITIES.map { |s| [s.capitalize, s] },
+          @ransack_query.severity_eq
+        ),
+        {},
+        { class: "input" }
+      %>
+      <%= link_to "Reset", findings_path, class: "btn btn--plain" if params.has_key?(:q) %>
+      <%= form.submit "Search", class: "btn" %>
+    </div>
+  <% end %>
+
+  <% if @table_data.any? %>
+    <div data-controller="rails-pulse--table-sort">
+      <div id="index_table" data-rails-pulse--table-sort-target="tableFrame">
+        <%= render 'rails_pulse/findings/table' %>
+      </div>
+    </div>
+  <% else %>
+    <%= render 'rails_pulse/components/empty_state',
+        title: 'No findings.',
+        description: 'Regressions appear here once enough history exists to compare against. Detection runs daily, after the summary job writes each completed day.' %>
+  <% end %>
+<% end %>

--- a/app/views/rails_pulse/findings/show.html.erb
+++ b/app/views/rails_pulse/findings/show.html.erb
@@ -1,0 +1,87 @@
+<%= render 'rails_pulse/components/page_header' %>
+
+<%= render 'rails_pulse/components/panel', title: @finding.subject_label do %>
+  <div class="flex gap items-center mbe-4">
+    <%= render 'rails_pulse/findings/severity_badge', finding: @finding %>
+    <%= render 'rails_pulse/findings/status_badge', finding: @finding %>
+    <span class="text-subtle text-sm">
+      <%= finding_metric_label(@finding) %> regression
+    </span>
+  </div>
+
+  <dl class="flex gap flex-wrap">
+    <div>
+      <dt class="text-subtle text-xs uppercase">Baseline</dt>
+      <dd class="font-semibold"><%= finding_baseline_display(@finding) %></dd>
+    </div>
+    <div>
+      <dt class="text-subtle text-xs uppercase">Current</dt>
+      <dd class="font-semibold"><%= finding_current_display(@finding) %></dd>
+    </div>
+    <div>
+      <dt class="text-subtle text-xs uppercase">Change</dt>
+      <dd class="font-semibold">
+        <%= @finding.percent_change ? "+#{number_with_delimiter(@finding.percent_change.round(0).to_i)}%" : "—" %>
+      </dd>
+    </div>
+    <div>
+      <dt class="text-subtle text-xs uppercase">Observations</dt>
+      <dd class="font-semibold">
+        <%= number_with_delimiter(@finding.baseline_count.to_i) %> baseline /
+        <%= number_with_delimiter(@finding.current_count.to_i) %> current
+      </dd>
+    </div>
+  </dl>
+<% end %>
+
+<%= render 'rails_pulse/components/panel', title: 'When it changed' do %>
+  <% if @finding.change_point_known? %>
+    <p class="text-sm">
+      Behaviour changed around
+      <strong><%= human_readable_occurred_at(@finding.changed_at) %></strong>.
+      <% unless @finding.hourly_change_point? %>
+        <span class="text-subtle">
+          Estimated to the day — hourly summaries are pruned at
+          <%= distance_of_time_in_words(RailsPulse.configuration.hourly_summary_retention) %>,
+          so an hour-accurate change point is only available for recent changes.
+        </span>
+      <% end %>
+    </p>
+  <% else %>
+    <p class="text-sm text-subtle">
+      No change point could be located. This happens when the metric drifted
+      rather than stepped, or when there are too few periods to split.
+    </p>
+  <% end %>
+
+  <% if @deployment %>
+    <p class="text-sm mbs-2">
+      Deployment <code><%= @deployment.revision %></code> started
+      <%= human_readable_occurred_at(@deployment.started_at) %>,
+      close to the estimated change point.
+      <span class="text-subtle">
+        This is adjacency, not proof — it is a place to look first.
+      </span>
+    </p>
+  <% end %>
+<% end %>
+
+<%= render 'rails_pulse/components/panel', title: 'Actions' do %>
+  <div class="flex gap items-center">
+    <% if @finding.subject %>
+      <%= link_to "View #{@finding.subject_type.demodulize.downcase}", finding_subject_path(@finding), class: "btn" if finding_subject_path(@finding) %>
+    <% end %>
+
+    <% if @finding.status == "open" %>
+      <%= button_to "Acknowledge", finding_path(@finding, status: "acknowledged"), method: :patch, class: "btn" %>
+    <% elsif @finding.status == "acknowledged" %>
+      <%= button_to "Reopen", finding_path(@finding, status: "open"), method: :patch, class: "btn" %>
+    <% end %>
+  </div>
+
+  <p class="text-subtle text-xs mbs-2">
+    Findings resolve themselves when detection stops seeing them, so there is no
+    resolve button — marking one resolved by hand would be contradicted by the
+    next detection run.
+  </p>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ RailsPulse::Engine.routes.draw do
     end
   end
   resources :operations, only: %i[show]
+  resources :findings, only: %i[index show update]
   if RailsPulse.configuration.track_exceptions
     resources :exceptions, only: %i[index show update] do
       resources :occurrences, only: %i[show], controller: "exception_occurrences"
@@ -29,8 +30,9 @@ RailsPulse::Engine.routes.draw do
   post "tags/:taggable_type/:taggable_id/add", to: "tags#create", as: :add_tag
   delete "tags/:taggable_type/:taggable_id/remove", to: "tags#destroy", as: :remove_tag
 
-  # Deployment event recording (API endpoint for CI/CD)
-  resources :deployments, only: [ :create ] do
+  # Deployments are both an API endpoint for CI/CD and a browsable record of
+  # what shipped when.
+  resources :deployments, only: %i[index show create] do
     collection do
       put :finish
     end

--- a/lib/rails_pulse/engine.rb
+++ b/lib/rails_pulse/engine.rb
@@ -20,6 +20,7 @@ module RailsPulse
   autoload :TagFilterService, File.expand_path("../../app/services/rails_pulse/tag_filter_service", __dir__)
   autoload :ExceptionCaptureService, File.expand_path("../../app/services/rails_pulse/exception_capture_service", __dir__)
   autoload :ExceptionMessageSanitizer, File.expand_path("../../app/services/rails_pulse/exception_message_sanitizer", __dir__)
+  autoload :DeploymentCorrelator, File.expand_path("../../app/services/rails_pulse/deployment_correlator", __dir__)
   autoload :FindingDetector, File.expand_path("../../app/services/rails_pulse/finding_detector", __dir__)
   autoload :OperationSuggestions, File.expand_path("../../app/services/rails_pulse/operation_suggestions", __dir__)
   autoload :RoutePathNormalizer,             File.expand_path("../../app/services/rails_pulse/route_path_normalizer", __dir__)

--- a/test/controllers/rails_pulse/deployments_controller_test.rb
+++ b/test/controllers/rails_pulse/deployments_controller_test.rb
@@ -1,7 +1,11 @@
 require "test_helper"
 
 class RailsPulse::DeploymentsControllerTest < ActionDispatch::IntegrationTest
-  fixtures :rails_pulse_deployments
+  include Rails::Controller::Testing::TestProcess
+  include Rails::Controller::Testing::TemplateAssertions
+  include Rails::Controller::Testing::Integration
+
+  fixtures :rails_pulse_deployments, :rails_pulse_routes, :rails_pulse_findings
 
   DEPLOY_TOKEN = "test-deploy-token"
 
@@ -28,6 +32,84 @@ class RailsPulse::DeploymentsControllerTest < ActionDispatch::IntegrationTest
   end
 
   # POST /deployments
+
+  # Index Action Tests
+
+  test "index responds successfully" do
+    get rails_pulse.deployments_path
+
+    assert_response :success
+  end
+
+  test "index assigns deployments newest first" do
+    get rails_pulse.deployments_path
+
+    timestamps = assigns(:table_data).map(&:started_at)
+
+    assert_equal timestamps.sort.reverse, timestamps
+  end
+
+  test "index renders an empty state with no deployments" do
+    RailsPulse::Deployment.delete_all
+
+    get rails_pulse.deployments_path
+
+    assert_response :success
+    assert_empty assigns(:table_data)
+  end
+
+  # Show Action Tests
+
+  test "show responds successfully" do
+    deployment = rails_pulse_deployments(:v1_deploy)
+
+    get rails_pulse.deployment_path(deployment)
+
+    assert_response :success
+    assert_equal deployment, assigns(:deployment)
+  end
+
+  test "show renders deployment metadata" do
+    deployment = rails_pulse_deployments(:v2_deploy)
+
+    get rails_pulse.deployment_path(deployment)
+
+    assert_includes response.body, "production"
+  end
+
+  test "show assigns correlated findings" do
+    deployment = rails_pulse_deployments(:v1_deploy)
+
+    get rails_pulse.deployment_path(deployment)
+
+    assert_not_nil assigns(:findings)
+  end
+
+  test "show correlates a finding whose change point follows the deployment" do
+    deployment = rails_pulse_deployments(:v1_deploy)
+    finding = RailsPulse::Finding.create!(
+      fingerprint:       SecureRandom.hex(32),
+      kind:              "performance_regression",
+      subject_type:      "RailsPulse::Route",
+      subject_id:        rails_pulse_routes(:api_users).id,
+      metric:            "p95",
+      severity:          "warning",
+      status:            "open",
+      baseline_value:    100.0,
+      current_value:     500.0,
+      delta:             400.0,
+      ratio:             5.0,
+      changed_at:        deployment.started_at + 30.minutes,
+      change_point_granularity: "hour",
+      first_detected_at: 1.hour.ago,
+      last_detected_at:  1.hour.ago,
+      detection_count:   1
+    )
+
+    get rails_pulse.deployment_path(deployment)
+
+    assert_includes assigns(:findings), finding
+  end
 
   test "create records deployment and returns 201" do
     assert_difference -> { RailsPulse::Deployment.count }, 1 do

--- a/test/controllers/rails_pulse/findings_controller_test.rb
+++ b/test/controllers/rails_pulse/findings_controller_test.rb
@@ -1,0 +1,151 @@
+require "test_helper"
+
+class RailsPulse::FindingsControllerTest < ActionDispatch::IntegrationTest
+  include Rails::Controller::Testing::TestProcess
+  include Rails::Controller::Testing::TemplateAssertions
+  include Rails::Controller::Testing::Integration
+
+  fixtures :rails_pulse_findings, :rails_pulse_routes, :rails_pulse_deployments
+
+  def setup
+    ENV["TEST_TYPE"] = "functional"
+    super
+    @finding = rails_pulse_findings(:open_route_regression)
+  end
+
+  # Index Action Tests
+
+  test "index responds successfully" do
+    get rails_pulse.findings_path
+
+    assert_response :success
+  end
+
+  test "index assigns table data and pagination" do
+    get rails_pulse.findings_path
+
+    assert_not_nil assigns(:table_data)
+    assert_not_nil assigns(:pagination)
+  end
+
+  test "index defaults to open findings" do
+    get rails_pulse.findings_path
+
+    statuses = assigns(:table_data).map(&:status).uniq
+
+    assert_equal [ "open" ], statuses
+  end
+
+  test "index shows all statuses when the filter is blank" do
+    get rails_pulse.findings_path, params: { q: { status_eq: "" } }
+
+    statuses = assigns(:table_data).map(&:status).uniq
+
+    assert_includes statuses, "resolved"
+  end
+
+  test "index filters by severity" do
+    get rails_pulse.findings_path, params: { q: { status_eq: "", severity_eq: "critical" } }
+
+    severities = assigns(:table_data).map(&:severity).uniq
+
+    assert_equal [ "critical" ], severities
+  end
+
+  test "index assigns correlated deployments" do
+    get rails_pulse.findings_path
+
+    assert_not_nil assigns(:deployments)
+  end
+
+  test "index renders an empty state with no findings" do
+    RailsPulse::Finding.delete_all
+
+    get rails_pulse.findings_path
+
+    assert_response :success
+    assert_empty assigns(:table_data)
+  end
+
+  # Show Action Tests
+
+  test "show responds successfully" do
+    get rails_pulse.finding_path(@finding)
+
+    assert_response :success
+  end
+
+  test "show assigns the finding and resolves its subject label" do
+    get rails_pulse.finding_path(@finding)
+
+    assert_equal @finding, assigns(:finding)
+    # The finding points at a real route, so the page names the path rather
+    # than falling back to "Route #id".
+    assert_includes response.body, "/api/users"
+  end
+
+  test "show renders a finding whose subject has been cleaned up" do
+    # Retention can delete a route while a finding about it is still open.
+    orphan = RailsPulse::Finding.create!(
+      fingerprint:       SecureRandom.hex(32),
+      kind:              "performance_regression",
+      subject_type:      "RailsPulse::Route",
+      subject_id:        999_999,
+      metric:            "p95",
+      severity:          "warning",
+      status:            "open",
+      baseline_value:    100.0,
+      current_value:     400.0,
+      delta:             300.0,
+      ratio:             4.0,
+      first_detected_at: 1.day.ago,
+      last_detected_at:  1.hour.ago,
+      detection_count:   1
+    )
+
+    get rails_pulse.finding_path(orphan)
+
+    assert_response :success
+  end
+
+  test "show renders a finding with no change point" do
+    finding = rails_pulse_findings(:acknowledged_error_rate_regression)
+
+    get rails_pulse.finding_path(finding)
+
+    assert_response :success
+    assert_includes response.body, "No change point"
+  end
+
+  # Update Action Tests
+
+  test "acknowledging an open finding" do
+    patch rails_pulse.finding_path(@finding, status: "acknowledged")
+
+    assert_redirected_to rails_pulse.finding_path(@finding)
+    assert_equal "acknowledged", @finding.reload.status
+  end
+
+  test "reopening an acknowledged finding" do
+    finding = rails_pulse_findings(:acknowledged_error_rate_regression)
+
+    patch rails_pulse.finding_path(finding, status: "open")
+
+    assert_equal "open", finding.reload.status
+  end
+
+  test "an unknown status is rejected" do
+    patch rails_pulse.finding_path(@finding, status: "banana")
+
+    assert_redirected_to rails_pulse.finding_path(@finding)
+    assert_equal "open", @finding.reload.status
+  end
+
+  test "resolving by hand is not offered" do
+    # Findings resolve when detection stops seeing them; a manual resolve would
+    # be contradicted by the next run.
+    patch rails_pulse.finding_path(@finding, status: "resolved")
+
+    assert_equal "open", @finding.reload.status
+  end
+end

--- a/test/fixtures/rails_pulse_findings.yml
+++ b/test/fixtures/rails_pulse_findings.yml
@@ -3,10 +3,10 @@
 # each test having to build a full baseline history first.
 
 open_route_regression:
-  fingerprint: <%= Digest::SHA256.hexdigest("performance_regression:RailsPulse::Route:1:p95") %>
+  fingerprint: <%= Digest::SHA256.hexdigest("performance_regression:RailsPulse::Route:#{ActiveRecord::FixtureSet.identify(:api_users)}:p95") %>
   kind: "performance_regression"
   subject_type: "RailsPulse::Route"
-  subject_id: 1
+  subject_id: <%= ActiveRecord::FixtureSet.identify(:api_users) %>
   metric: "p95"
   severity: "critical"
   status: "open"
@@ -25,10 +25,10 @@ open_route_regression:
   updated_at: <%= 1.hour.ago %>
 
 open_query_regression:
-  fingerprint: <%= Digest::SHA256.hexdigest("performance_regression:RailsPulse::Query:1:p95") %>
+  fingerprint: <%= Digest::SHA256.hexdigest("performance_regression:RailsPulse::Query:#{ActiveRecord::FixtureSet.identify(:simple_query)}:p95") %>
   kind: "performance_regression"
   subject_type: "RailsPulse::Query"
-  subject_id: 1
+  subject_id: <%= ActiveRecord::FixtureSet.identify(:simple_query) %>
   metric: "p95"
   severity: "warning"
   status: "open"
@@ -47,10 +47,10 @@ open_query_regression:
   updated_at: <%= 1.hour.ago %>
 
 acknowledged_error_rate_regression:
-  fingerprint: <%= Digest::SHA256.hexdigest("error_rate_regression:RailsPulse::Route:2:error_rate") %>
+  fingerprint: <%= Digest::SHA256.hexdigest("error_rate_regression:RailsPulse::Route:#{ActiveRecord::FixtureSet.identify(:api_posts)}:error_rate") %>
   kind: "error_rate_regression"
   subject_type: "RailsPulse::Route"
-  subject_id: 2
+  subject_id: <%= ActiveRecord::FixtureSet.identify(:api_posts) %>
   metric: "error_rate"
   severity: "critical"
   status: "acknowledged"
@@ -67,10 +67,10 @@ acknowledged_error_rate_regression:
   updated_at: <%= 2.hours.ago %>
 
 resolved_route_regression:
-  fingerprint: <%= Digest::SHA256.hexdigest("performance_regression:RailsPulse::Route:3:p95") %>
+  fingerprint: <%= Digest::SHA256.hexdigest("performance_regression:RailsPulse::Route:#{ActiveRecord::FixtureSet.identify(:api_test)}:p95") %>
   kind: "performance_regression"
   subject_type: "RailsPulse::Route"
-  subject_id: 3
+  subject_id: <%= ActiveRecord::FixtureSet.identify(:api_test) %>
   metric: "p95"
   severity: "warning"
   status: "resolved"

--- a/test/services/rails_pulse/deployment_correlator_test.rb
+++ b/test/services/rails_pulse/deployment_correlator_test.rb
@@ -1,0 +1,140 @@
+require "test_helper"
+
+module RailsPulse
+  class DeploymentCorrelatorTest < ActiveSupport::TestCase
+    fixtures :rails_pulse_routes
+
+    def setup
+      @now = Time.utc(2026, 6, 15, 12, 0, 0)
+      travel_to @now
+      RailsPulse::Deployment.delete_all
+      RailsPulse::Finding.delete_all
+    end
+
+    def teardown
+      travel_back
+    end
+
+    def deployment_at(time, revision: SecureRandom.hex(6))
+      RailsPulse::Deployment.create!(revision: revision, started_at: time)
+    end
+
+    def finding_with_change_point(changed_at, granularity: "hour")
+      RailsPulse::Finding.create!(
+        fingerprint:       SecureRandom.hex(32),
+        kind:              "performance_regression",
+        subject_type:      "RailsPulse::Route",
+        subject_id:        rails_pulse_routes(:api_users).id,
+        metric:            "p95",
+        severity:          "warning",
+        status:            "open",
+        baseline_value:    200.0,
+        current_value:     900.0,
+        delta:             700.0,
+        ratio:             4.5,
+        changed_at:        changed_at,
+        change_point_granularity: granularity,
+        first_detected_at: @now,
+        last_detected_at:  @now,
+        detection_count:   1
+      )
+    end
+
+    # Structure Tests
+
+    test "returns the deployment shortly before an hourly change point" do
+      deployment = deployment_at(@now - 3.hours)
+      finding    = finding_with_change_point(@now - 2.hours)
+
+      assert_equal deployment, DeploymentCorrelator.for(finding)
+    end
+
+    test "returns nil when no deployment is close enough" do
+      deployment_at(@now - 3.days)
+      finding = finding_with_change_point(@now - 2.hours)
+
+      assert_nil DeploymentCorrelator.for(finding)
+    end
+
+    test "returns nil when the finding has no change point" do
+      deployment_at(@now - 1.hour)
+      finding = finding_with_change_point(nil, granularity: nil)
+
+      assert_nil DeploymentCorrelator.for(finding)
+    end
+
+    # Selection Tests
+
+    test "picks the most recent deployment when several are in range" do
+      deployment_at(@now - 5.hours)
+      nearest = deployment_at(@now - 3.hours)
+      finding = finding_with_change_point(@now - 2.hours)
+
+      assert_equal nearest, DeploymentCorrelator.for(finding)
+    end
+
+    test "does not pick a deployment after an hourly change point" do
+      # An hourly change point is accurate, so a deploy that happened afterwards
+      # cannot have caused it.
+      deployment_at(@now - 1.hour)
+      finding = finding_with_change_point(@now - 2.hours)
+
+      assert_nil DeploymentCorrelator.for(finding)
+    end
+
+    test "a daily change point admits deployments later in that day" do
+      # The change point only identifies the day, so a deploy that morning is a
+      # candidate even though its timestamp is after the midnight boundary.
+      day        = (@now - 2.days).beginning_of_day
+      deployment = deployment_at(day + 9.hours)
+      finding    = finding_with_change_point(day, granularity: "day")
+
+      assert_equal deployment, DeploymentCorrelator.for(finding)
+    end
+
+    # Batch Tests
+
+    test "for_all correlates a batch" do
+      deployment = deployment_at(@now - 3.hours)
+      finding    = finding_with_change_point(@now - 2.hours)
+
+      correlated = DeploymentCorrelator.for_all([ finding ])
+
+      assert_equal deployment, correlated[finding.id]
+    end
+
+    test "for_all omits findings with no match" do
+      finding = finding_with_change_point(@now - 2.hours)
+
+      assert_empty DeploymentCorrelator.for_all([ finding ])
+    end
+
+    test "for_all skips findings without a change point" do
+      deployment_at(@now - 1.hour)
+      finding = finding_with_change_point(nil, granularity: nil)
+
+      assert_empty DeploymentCorrelator.for_all([ finding ])
+    end
+
+    test "for_all handles an empty batch" do
+      assert_empty DeploymentCorrelator.for_all([])
+    end
+
+    # Edge Cases
+
+    test "a deployment exactly at the change point counts" do
+      deployment = deployment_at(@now - 2.hours)
+      finding    = finding_with_change_point(@now - 2.hours)
+
+      assert_equal deployment, DeploymentCorrelator.for(finding)
+    end
+
+    test "the window is configurable" do
+      deployment_at(@now - 20.hours)
+      finding = finding_with_change_point(@now - 2.hours)
+
+      assert_nil DeploymentCorrelator.for(finding)
+      assert_not_nil DeploymentCorrelator.for(finding, window: 24.hours)
+    end
+  end
+end


### PR DESCRIPTION
**Step 4 of 4** in the OSS V1 track. Stacked on #209 → #208 → #207 — **base those first**, this targets `oss-v1/exceptions-first-class`.

## Why

#208 made findings records, but they had nowhere to appear except the dashboard's attention list. And deployments have been recorded since 0.4.0 while only ever being visible as markers on a chart: there was no way to see what shipped when, and `deploy_sha` was faithfully written onto every exception occurrence and read by nothing.

## What this adds

**A findings UI** — index, detail, acknowledge/reopen.

**`DeploymentCorrelator`** — the deployment a regression most plausibly belongs to.

**Deployment pages** — an index of what shipped when, and per-deployment, the regressions that line up with it.

**Nav entries** for both.

## Design decisions worth reviewing

**There is deliberately no manual "resolve" button.** Findings resolve when detection stops seeing them, so a hand-set resolved status would be contradicted by the next run — the user would resolve something and watch it come back, which reads as a bug. Acknowledging is the action that means "I've seen this", and it survives redetection. If a manual resolve is wanted, it needs a suppression concept, which is a bigger design than this PR.

**Correlation is derived at read time, not stored on the finding.** CI often records a deployment moments after the code is live, and sometimes late or retroactively. Correlating on read means a deployment recorded *after* detection still lines up, where a `deployment_id` column written once would be permanently wrong. Both inputs are already persisted, so nothing is lost by deriving it — and it avoids a migration.

⚠️ The counter-argument: Pro might want the correlation persisted. I think that's premature — it's derivable, and denormalizing it now buys a stale column.

**An hourly change point only admits earlier deployments; a daily one admits deployments later that day.** An hourly estimate is accurate, so a deploy afterwards can't have caused it. A daily estimate only identifies the day, so a deploy that morning is still a candidate.

**The UI says adjacency, not causation.** "close to the estimated change point… this is adjacency, not proof — it is a place to look first." A deployment near a regression is a lead, and overstating it would train users to distrust the feature.

**The detail page states how precisely the change point is known** rather than rendering a timestamp implying more accuracy than exists.

**`skip_before_action :authenticate_rails_pulse_user!` is now scoped to `create`/`finish`.** The API actions keep token auth; the new pages authenticate like every other dashboard page. Adding a UI must not widen the hole the 0.4.0 audit closed (§7/§19).

⚠️ **The 6-hour correlation window (`DeploymentCorrelator::DEFAULT_WINDOW`) is a guess.** Wide enough to absorb deploy-to-metric lag, narrow enough not to blame a deploy from days earlier. Worth a second opinion.

## Two incidental fixes

`FindingsHelper` is registered in `ApplicationHelper`. Rails only auto-includes a helper for its matching controller, so the deployments views couldn't see it — caught by a test, not by inspection.

Findings fixtures now use `ActiveRecord::FixtureSet.identify` instead of hardcoded ids, so `subject_label` resolves to a real path rather than always falling back to `Route #1`. That fallback path is still covered by its own test.

## Tests

27 new tests (12 correlator, 15 findings controller) plus 7 deployment page tests.

Full suite green: **3262 runs, 8845 assertions, 0 failures, 0 errors**, plus **22 migration tests**. RuboCop clean. Brakeman back to main's 2 warnings.

Covers window boundaries in both directions, hourly-vs-daily candidate rules, batch correlation, and rendering a finding whose subject has been deleted by retention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BaximWeiDUL64Mr5RXWi4n