### PR TITLE
Redact exception messages for real, and job failure messages too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet._
+### Security
+
+- **Exception messages are now actually redacted.** The 0.4.0 sanitizer ran
+  `ActiveSupport::ParameterFilter` in a way that only fired when the host
+  filtered a key literally named `message`, so `password=…`, `token: …`, and
+  MySQL `Duplicate entry '<value>'` messages were stored verbatim. Messages now
+  have `key=value` / `key: value` / `"key":"value"` fragments masked whenever the
+  key matches `config.filter_parameters` (same rules as logged params), MySQL
+  duplicate-entry values are redacted alongside the existing PostgreSQL
+  `DETAIL:` clause, and job-run failure messages (`rails_pulse_job_runs.error_message`)
+  go through the same sanitizer instead of being stored raw and unbounded.
+
+### Added
+
+- **`exception_message_filter` config option** — an optional `->(message, exception)`
+  hook applied after the built-in redaction for app-specific patterns. If the hook
+  raises, the message is stored as `[FILTERED]` rather than unfiltered.
 
 ## [0.4.0.pre.1] - 2026-08-29
 

--- a/app/services/rails_pulse/exception_message_sanitizer.rb
+++ b/app/services/rails_pulse/exception_message_sanitizer.rb
@@ -2,18 +2,53 @@ module RailsPulse
   # Strips PII from exception messages before they are persisted or exported.
   #
   # Extracted from ExceptionCaptureService so the same filtering applies to
-  # occurrence rows and to anything that ships a message off the machine
-  # (see RailsPulse::Exceptions::RawData).
+  # occurrence rows, job-run failure messages, and anything that ships a
+  # message off the machine (see RailsPulse::Exceptions::RawData).
+  #
+  # Three layers, applied in order:
+  #
+  # 1. Adapter-specific cleanup for ActiveRecord::StatementInvalid — the
+  #    driver error is kept, the offending statement and any literal values
+  #    the database echoes back (PG `DETAIL: Key (col)=(val)`, MySQL
+  #    `Duplicate entry 'val'`) are redacted.
+  # 2. `key=value` / `key: value` / `"key":"value"` pairs anywhere in the
+  #    text whose key matches the host's `config.filter_parameters` — the
+  #    same rules Rails applies to logged params, so `password=hunter2` and
+  #    `token: abc` are masked without any extra configuration.
+  # 3. An optional host hook, `config.exception_message_filter`, for anything
+  #    the generic rules cannot know about.
   class ExceptionMessageSanitizer
     MAX_LENGTH = 500
+    FILTERED = "[FILTERED]".freeze
+
+    # Matches `key=value`, `key: value`, `'key' => value` and JSON-style
+    # `"key":"value"` fragments in free text. A bare `:` only counts as a
+    # separator after a quoted key or when followed by whitespace, so URL
+    # schemes (`https://…`) and clock times (`12:30`) are not read as pairs.
+    # The value is a quoted string (with escapes) or a run of characters up
+    # to the next delimiter — including `&` and `?`, so query strings split
+    # per key. An unquoted value may not end right before another `=` or `:`
+    # (atomic, so `Error: token: x` is not read as `Error` = `token`), but
+    # may contain `://` so URLs survive as one value.
+    KEY_VALUE_PAIR = /
+      (?<lead>["'])?
+      (?<key>[A-Za-z_][\w.\-\[\]]*)
+      (?(<lead>)\k<lead>)
+      (?<sep>\s*=>\s*|\s*=\s*|\s*:\s+|(?(<lead>):|(?!)))
+      (?<value>
+        "(?:[^"\\]|\\.)*"
+        | '(?:[^'\\]|\\.)*'
+        | (?>(?:[^\s,;)\]}&\#?=:]|:(?=\/\/))+)(?![=:]|\s*=>)
+      )
+    /x
 
     class << self
-      def call(message, statement_invalid: false)
-        new(message, statement_invalid: statement_invalid).call
+      def call(message, statement_invalid: false, exception: nil)
+        new(message, statement_invalid: statement_invalid, exception: exception).call
       end
 
       def for_exception(exception)
-        call(exception.message.to_s, statement_invalid: statement_invalid?(exception))
+        call(exception.message.to_s, statement_invalid: statement_invalid?(exception), exception: exception)
       end
 
       private
@@ -24,37 +59,94 @@ module RailsPulse
       end
     end
 
-    def initialize(message, statement_invalid: false)
+    def initialize(message, statement_invalid: false, exception: nil)
       @message = message.to_s
       @statement_invalid = statement_invalid
+      @exception = exception
     end
 
     def call
       message = @message
-
-      # Strip the appended SQL statement from ActiveRecord::StatementInvalid
-      # which embeds the offending query including literal PII values.
-      if @statement_invalid
-        message = message.split("\n").first.to_s
-        message = message.sub(/\s*:\s*(?:INSERT|UPDATE|DELETE|SELECT)\b.*/i, "")
-        # Redact DETAIL: Key (col)=(value) clauses from PG unique violations
-        message = message.gsub(/DETAIL:\s*Key\s*\([^)]*\)=\([^)]*\)/, "DETAIL: Key (…)=(…)")
-      end
-
-      # Apply Rails' parameter filter in key=value mode
-      if defined?(ActiveSupport::ParameterFilter) && (patterns = filter_parameters).any?
-        message = ActiveSupport::ParameterFilter.new(patterns).filter_param("message", message)
-      end
-
+      message = redact_statement_invalid(message) if @statement_invalid
+      message = filter_key_value_pairs(message)
+      message = apply_custom_filter(message)
       message.truncate(MAX_LENGTH)
     end
 
     private
 
+    def redact_statement_invalid(message)
+      # Strip the appended SQL statement, which embeds the offending query
+      # including literal PII values.
+      message = message.split("\n").first.to_s
+      message = message.sub(/\s*:\s*(?:INSERT|UPDATE|DELETE|SELECT)\b.*/i, "")
+      # PostgreSQL: DETAIL: Key (email)=(alice@example.com) already exists.
+      message = message.gsub(/DETAIL:\s*Key\s*\([^)]*\)=\([^)]*\)/, "DETAIL: Key (…)=(…)")
+      # MySQL puts the offending value on the first line, ahead of the SQL:
+      # Duplicate entry 'alice@example.com' for key 'index_users_on_email'
+      message.gsub(/Duplicate entry '(?:[^'\\]|\\.)*'/i, "Duplicate entry '#{FILTERED}'")
+    end
+
+    # Rails' ParameterFilter only masks by key, so on its own it does nothing
+    # for a message like "login failed password=hunter2". Scan the text for
+    # key/value fragments and ask the filter about each key individually —
+    # this reuses the host's exact matching rules (substring, regexp, and
+    # proc filters alike).
+    def filter_key_value_pairs(message)
+      filter = parameter_filter
+      return message unless filter
+
+      # A host that filters a key literally named "message" wants the whole
+      # thing gone; honour that before looking inside it.
+      whole = filter.filter_param("message", message)
+      return whole unless whole.equal?(message)
+
+      message.gsub(KEY_VALUE_PAIR) do
+        match = Regexp.last_match
+        key   = match[:key]
+        value = match[:value]
+
+        if filter.filter(key => value)[key] == value
+          match[0]
+        else
+          lead = match[:lead].to_s
+          "#{lead}#{key}#{lead}#{match[:sep]}#{FILTERED}"
+        end
+      end
+    end
+
+    def apply_custom_filter(message)
+      hook = custom_filter
+      return message unless hook
+
+      result = hook.arity == 1 ? hook.call(message) : hook.call(message, @exception)
+      result.to_s
+    rescue => e
+      # The hook exists to remove sensitive data; if it blows up, storing the
+      # unfiltered message would defeat its purpose. Fail closed.
+      RailsPulse.logger.warn("[RailsPulse] exception_message_filter raised #{e.class}: #{e.message}; message redacted")
+      FILTERED
+    end
+
+    def parameter_filter
+      patterns = filter_parameters
+      return nil if patterns.blank?
+      return nil unless defined?(ActiveSupport::ParameterFilter)
+
+      ActiveSupport::ParameterFilter.new(patterns)
+    end
+
     def filter_parameters
       Rails.application.config.filter_parameters
     rescue
       []
+    end
+
+    def custom_filter
+      hook = RailsPulse.configuration&.exception_message_filter
+      hook if hook.respond_to?(:call)
+    rescue
+      nil
     end
   end
 end

--- a/lib/generators/rails_pulse/templates/rails_pulse.rb
+++ b/lib/generators/rails_pulse/templates/rails_pulse.rb
@@ -132,8 +132,11 @@ RailsPulse.configure do |config|
   # upgrade. New apps get true from this template; the upgrade generator
   # inserts false into existing initializers.
   #
-  # Backtraces store the first 50 frames. Exception messages are stored as raised
-  # (not filtered); request params are filtered via Rails' filter_parameters.
+  # Backtraces store the first 50 frames. Request params are filtered via Rails'
+  # filter_parameters. Exception messages are filtered too: the SQL and echoed
+  # values in ActiveRecord::StatementInvalid messages are stripped, and any
+  # `key=value` / `key: value` fragment whose key matches filter_parameters
+  # (password=…, token: …) is masked. Messages are truncated to 500 characters.
 
   # Enable or disable exception tracking
   config.track_exceptions = true
@@ -143,6 +146,13 @@ RailsPulse.configure do |config|
   # Occurrences with params larger than 10KB after filtering are stored without params.
   # Set to false to disable entirely, e.g. for strict data-minimization requirements.
   config.capture_exception_params = true
+
+  # Extra redaction for exception messages, applied after the built-in
+  # filter_parameters pass. Receives the message and the exception; return the
+  # message to store. If the hook raises, the message is stored as "[FILTERED]".
+  # config.exception_message_filter = ->(message, exception) {
+  #   message.gsub(/\b\d{13,16}\b/, "[FILTERED]")   # card-number-shaped digits
+  # }
 
   # How many times an exception group has to fire over the dashboard period
   # before it is called out. These are occurrence counts, not durations.

--- a/lib/generators/rails_pulse/upgrade_generator.rb
+++ b/lib/generators/rails_pulse/upgrade_generator.rb
@@ -109,8 +109,9 @@ module RailsPulse
 
             config.track_exceptions = true
 
-          New installs enable this in the generated initializer. Messages are
-          stored unfiltered; request params use Rails filter_parameters.
+          New installs enable this in the generated initializer. Messages and
+          request params are both redacted using Rails filter_parameters; set
+          config.exception_message_filter for anything app-specific.
 
           Two new tables will be created:
             - rails_pulse_exception_groups

--- a/lib/rails_pulse/configuration.rb
+++ b/lib/rails_pulse/configuration.rb
@@ -11,6 +11,7 @@ module RailsPulse
                   :track_jobs,
                   :track_exceptions,
                   :capture_exception_params,
+                  :exception_message_filter,
                   :capture_actual_sql,
                   :custom_asset_patterns,
                   :mount_path,
@@ -73,6 +74,9 @@ module RailsPulse
       # default would start capturing exception messages (unfiltered) on upgrade.
       @track_exceptions = false
       @capture_exception_params = true
+      # Optional host hook applied to every captured exception message after
+      # the built-in filter_parameters redaction. nil means no extra filtering.
+      @exception_message_filter = nil
       # Off by default — actual_sql contains unparameterized SQL on mysql2
       # (prepared_statements: false) and PG behind PgBouncer transaction mode.
       # Inline literals (emails, passwords) would be stored in plaintext.
@@ -372,6 +376,10 @@ module RailsPulse
 
       unless [ true, false ].include?(@capture_exception_params)
         raise ArgumentError, "capture_exception_params must be a boolean"
+      end
+
+      if @exception_message_filter && !@exception_message_filter.respond_to?(:call)
+        raise ArgumentError, "exception_message_filter must respond to #call (a proc or lambda taking the message and the exception), got #{@exception_message_filter.class}"
       end
     end
 

--- a/lib/rails_pulse/job_run_collector.rb
+++ b/lib/rails_pulse/job_run_collector.rb
@@ -55,7 +55,9 @@ module RailsPulse
                 status: failure_status_for(error),
                 duration: duration,
                 error_class: error.class.name,
-                error_message: error.message
+                # Same redaction as exception occurrences — a job failure
+                # message can carry the same literal PII a request one can.
+                error_message: RailsPulse::ExceptionMessageSanitizer.for_exception(error)
               )
             end
           end

--- a/test/lib/rails_pulse/configuration_test.rb
+++ b/test/lib/rails_pulse/configuration_test.rb
@@ -246,6 +246,24 @@ module RailsPulse
       end
     end
 
+    test "exception_message_filter defaults to nil" do
+      assert_nil Configuration.new.exception_message_filter
+    end
+
+    test "validate_configuration! accepts a callable exception_message_filter" do
+      config = build_config { self.exception_message_filter = ->(message, _exception) { message } }
+
+      assert_respond_to config.exception_message_filter, :call
+    end
+
+    test "validate_configuration! raises for a non-callable exception_message_filter" do
+      config = Configuration.new
+      config.exception_message_filter = "not callable"
+
+      error = assert_raises(ArgumentError) { config.validate_configuration! }
+      assert_match "exception_message_filter", error.message
+    end
+
     test "validate_configuration! raises for invalid authentication_method type" do
       config = Configuration.new
       config.instance_variable_set(:@authentication_method, 42)

--- a/test/services/rails_pulse/exception_message_sanitizer_test.rb
+++ b/test/services/rails_pulse/exception_message_sanitizer_test.rb
@@ -4,6 +4,12 @@ module RailsPulse
   class ExceptionMessageSanitizerTest < ActiveSupport::TestCase
     def setup
       ENV["TEST_TYPE"] = "unit"
+      @original_filter = RailsPulse.configuration.exception_message_filter
+      super
+    end
+
+    def teardown
+      RailsPulse.configuration.exception_message_filter = @original_filter
       super
     end
 
@@ -21,7 +27,7 @@ module RailsPulse
       assert_equal "", ExceptionMessageSanitizer.call(nil)
     end
 
-    # Redaction Tests
+    # StatementInvalid Redaction Tests
 
     test "strips trailing sql from a statement invalid message" do
       message = "PG::UniqueViolation: ERROR: duplicate key: INSERT INTO users (email) VALUES ('a@b.com')"
@@ -41,6 +47,16 @@ module RailsPulse
       assert_includes result, "DETAIL: Key (…)=(…)"
     end
 
+    test "redacts mysql duplicate entry values" do
+      message = "Mysql2::Error: Duplicate entry 'alice@example.com' for key 'users.index_users_on_email': INSERT INTO `users` ..."
+
+      result = ExceptionMessageSanitizer.call(message, statement_invalid: true)
+
+      refute_includes result, "alice@example.com"
+      assert_includes result, "Duplicate entry '[FILTERED]' for key 'users.index_users_on_email'"
+      refute_includes result, "INSERT INTO"
+    end
+
     test "keeps only the first line of a statement invalid message" do
       result = ExceptionMessageSanitizer.call("first line\nsecond line", statement_invalid: true)
 
@@ -53,6 +69,127 @@ module RailsPulse
       assert_includes ExceptionMessageSanitizer.call(message), "SELECT 1"
     end
 
+    # filter_parameters Redaction Tests
+    #
+    # The dummy app filters :passw, :email, :secret, :token, :_key, :crypt,
+    # :salt, :certificate, :otp, :ssn, :cvv, :cvc — the Rails defaults.
+
+    test "redacts key=value pairs whose key matches filter_parameters" do
+      result = ExceptionMessageSanitizer.call("login failed password=hunter2 for bob")
+
+      refute_includes result, "hunter2"
+      assert_equal "login failed password=[FILTERED] for bob", result
+    end
+
+    test "redacts key: value pairs" do
+      result = ExceptionMessageSanitizer.call("Stripe::CardError: token: sk_live_abc123 was declined")
+
+      refute_includes result, "sk_live_abc123"
+      assert_includes result, "token: [FILTERED]"
+    end
+
+    test "redacts json style quoted pairs" do
+      result = ExceptionMessageSanitizer.call(%q(JSON::ParserError near {"email":"alice@example.com","plan":"pro"}))
+
+      refute_includes result, "alice@example.com"
+      assert_includes result, %q("email":[FILTERED])
+      assert_includes result, %q("plan":"pro")
+    end
+
+    test "redacts hash rocket pairs" do
+      result = ExceptionMessageSanitizer.call(%q(bad args {"api_key" => "abc123", "id" => 5}))
+
+      refute_includes result, "abc123"
+      assert_includes result, %q("id" => 5)
+    end
+
+    test "redacts values inside query strings" do
+      result = ExceptionMessageSanitizer.call("Faraday::ClientError: GET https://api.example.com/v1/me?token=abc&page=2 returned 401")
+
+      refute_includes result, "abc"
+      assert_includes result, "token=[FILTERED]"
+      assert_includes result, "page=2"
+    end
+
+    test "applies filter_parameters substring matching like rails does" do
+      result = ExceptionMessageSanitizer.call("csrf_token=xyz and passwd=123")
+
+      refute_includes result, "xyz"
+      refute_includes result, "123"
+    end
+
+    test "leaves pairs whose key does not match filter_parameters alone" do
+      message = "Couldn't find User with 'id'=42 and status=active"
+
+      assert_equal message, ExceptionMessageSanitizer.call(message)
+    end
+
+    test "redacts quoted values that contain spaces" do
+      result = ExceptionMessageSanitizer.call(%q(secret="hello world" ok))
+
+      assert_equal %q(secret=[FILTERED] ok), result
+    end
+
+    test "does not treat urls or times as pairs" do
+      message = "timeout at 12:30 fetching https://example.com/health"
+
+      assert_equal message, ExceptionMessageSanitizer.call(message)
+    end
+
+    test "filters the whole message when the host filters a key named message" do
+      with_filter_parameters([ :message ]) do
+        assert_equal "[FILTERED]", ExceptionMessageSanitizer.call("password=hunter2")
+      end
+    end
+
+    test "leaves messages untouched when filter_parameters is empty" do
+      with_filter_parameters([]) do
+        assert_equal "password=hunter2", ExceptionMessageSanitizer.call("password=hunter2")
+      end
+    end
+
+    # exception_message_filter Hook Tests
+
+    test "applies the configured exception_message_filter" do
+      RailsPulse.configuration.exception_message_filter = ->(message, _exception) { message.gsub(/\d{4}/, "####") }
+
+      assert_equal "card ending ####", ExceptionMessageSanitizer.call("card ending 4242")
+    end
+
+    test "supports a single argument exception_message_filter" do
+      RailsPulse.configuration.exception_message_filter = ->(message) { message.upcase }
+
+      assert_equal "BOOM", ExceptionMessageSanitizer.call("boom")
+    end
+
+    test "passes the exception to a two argument filter" do
+      seen = nil
+      RailsPulse.configuration.exception_message_filter = ->(message, exception) { seen = exception; message }
+      error = RuntimeError.new("boom")
+
+      ExceptionMessageSanitizer.for_exception(error)
+
+      assert_same error, seen
+    end
+
+    test "runs the hook after the built-in redaction" do
+      RailsPulse.configuration.exception_message_filter = ->(message, _) { message.sub("[FILTERED]", "<redacted>") }
+
+      assert_equal "password=<redacted>", ExceptionMessageSanitizer.call("password=hunter2")
+    end
+
+    test "fails closed when the hook raises" do
+      RailsPulse.configuration.exception_message_filter = ->(_message, _) { raise "hook broke" }
+
+      assert_equal "[FILTERED]", ExceptionMessageSanitizer.call("password=hunter2 secret stuff")
+    end
+
+    test "coerces a non string hook result" do
+      RailsPulse.configuration.exception_message_filter = ->(_message, _) { nil }
+
+      assert_equal "", ExceptionMessageSanitizer.call("boom")
+    end
+
     # Edge Cases
 
     test "for_exception detects statement invalid exceptions" do
@@ -63,6 +200,22 @@ module RailsPulse
 
     test "for_exception leaves ordinary exceptions alone" do
       assert_equal "plain failure", ExceptionMessageSanitizer.for_exception(RuntimeError.new("plain failure"))
+    end
+
+    test "for_exception redacts filtered pairs in ordinary exceptions" do
+      exception = RuntimeError.new("auth failed token=abc")
+
+      assert_equal "auth failed token=[FILTERED]", ExceptionMessageSanitizer.for_exception(exception)
+    end
+
+    private
+
+    def with_filter_parameters(patterns)
+      original = Rails.application.config.filter_parameters
+      Rails.application.config.filter_parameters = patterns
+      yield
+    ensure
+      Rails.application.config.filter_parameters = original
     end
   end
 end

--- a/test/services/rails_pulse/job_run_collector_test.rb
+++ b/test/services/rails_pulse/job_run_collector_test.rb
@@ -85,6 +85,22 @@ module RailsPulse
       assert_equal "boom", job_run.error_message
     end
 
+    test "track redacts the failure message like an exception occurrence" do
+      job = FakeJob.new
+
+      assert_raises RuntimeError do
+        RailsPulse::JobRunCollector.track(job) do
+          raise RuntimeError, "charge failed for token=tok_live_123 (" + ("x" * 600) + ")"
+        end
+      end
+
+      job_run = RailsPulse::JobRun.order(:created_at).last
+
+      refute_includes job_run.error_message, "tok_live_123"
+      assert_includes job_run.error_message, "token=[FILTERED]"
+      assert_operator job_run.error_message.length, :<=, 500
+    end
+
     test "track records a failed job as an exception occurrence" do
       job = FakeJob.new
 


### PR DESCRIPTION
## Problem

`ExceptionMessageSanitizer` ran `ActiveSupport::ParameterFilter#filter_param("message", message)`, described in a comment as "key=value mode". `ParameterFilter` has no such mode — it only masks when the **key** matches, so this fired only for hosts that filter a key literally named `message`. Verified against ActiveSupport 8.1.3:

```
filter_param("message", "login failed password=hunter2 token=abc")
# => "login failed password=hunter2 token=abc"        (unchanged)
"Mysql2::Error: Duplicate entry 'alice@example.com' for key 'index_users_on_email'"
# => stored verbatim; only PG's DETAIL: clause was redacted
```

Separately, `JobRunCollector` wrote `error.message` straight to `rails_pulse_job_runs.error_message` — no sanitizer, no 500-char cap.

## Fix

- **Real key/value scanning.** `key=value`, `key: value`, `"key":"value"` and `'key' => value` fragments are masked whenever the key matches `config.filter_parameters`. Each pair is passed through the host's own `ParameterFilter`, so substring (`:passw`), regexp and proc filters behave exactly as for logged params. URL schemes and clock times are not read as pairs; query strings split per key.
- **MySQL** `Duplicate entry '…'` values redacted on `StatementInvalid`, next to the PG `DETAIL:` handling.
- **Job failures** go through the same sanitizer (and are now capped at 500 chars).
- **`config.exception_message_filter`** — optional `->(message, exception)` hook applied after the built-in pass. If it raises, the message is stored as `[FILTERED]` rather than unfiltered.
- Template, upgrade notice and CHANGELOG no longer claim messages are stored unfiltered.

Known limit: a bare value with no key in front of it (`… declined for alice@example.com`) is out of scope for the generic pass — that's what the hook is for.

## Tests

- 17 new sanitizer cases (MySQL, `key: value`, JSON, hash-rocket, query strings, substring matching, non-matching keys, quoted values, URL/time false positives, `message` key, empty filters, hook arity/ordering/fail-closed).
- `JobRunCollector` redaction + cap.
- `Configuration` validation for the new option.

`DB=sqlite3 bin/rails test` on the touched suites: 211 runs, 0 failures. RuboCop clean.

Finding H1 from the security audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BaximWeiDUL64Mr5RXWi4n
