### PR TITLE
Declare protect_from_forgery in the engine instead of inheriting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   duplicate-entry values are redacted alongside the existing PostgreSQL
   `DETAIL:` clause, and job-run failure messages (`rails_pulse_job_runs.error_message`)
   go through the same sanitizer instead of being stored raw and unbounded.
+- **CSRF protection is now declared by the engine.** `RailsPulse::ApplicationController`
+  calls `protect_from_forgery with: :exception` itself instead of inheriting it from the
+  host's `default_protect_from_forgery`, which only `load_defaults 5.2+` enables. Hosts
+  on an older `load_defaults` had no CSRF protection on any engine endpoint (tags,
+  exception status, query reanalyze, session filters). Brakeman's `CheckForgerySetting`
+  is no longer skipped.
 
 ### Added
 

--- a/app/controllers/rails_pulse/application_controller.rb
+++ b/app/controllers/rails_pulse/application_controller.rb
@@ -3,6 +3,16 @@ module RailsPulse
     include PaginationConcern
     include SessionFiltersConcern
 
+    # Declared here rather than inherited. ActionController::Base only gets
+    # protect_from_forgery from the host's `default_protect_from_forgery`,
+    # which load_defaults 5.2+ turns on — a host still on an older
+    # load_defaults (or one that set the flag false and calls
+    # protect_from_forgery in its own ApplicationController) would leave every
+    # state-changing engine endpoint forgeable. Idempotent when the host
+    # already has it; the deployments API and assets controller keep their
+    # explicit skips.
+    protect_from_forgery with: :exception
+
     before_action :authenticate_rails_pulse_user!
     before_action :set_onboarding_state
     before_action :load_deployment_markers

--- a/config/brakeman.yml
+++ b/config/brakeman.yml
@@ -58,11 +58,8 @@
 :absolute_paths: false  # Use relative paths in reports
 :summary_only: false    # Show full details, not just summary
 
-# Engine-specific: Skip checks that don't apply to mountable engines
-# These checks are more relevant for standalone apps
-:skip_checks:
-  # Skip checks that are handled by the host application
-  - CheckForgerySetting  # CSRF protection is handled by host app
-
+# Note: CheckForgerySetting is deliberately NOT skipped. The engine declares
+# protect_from_forgery in RailsPulse::ApplicationController instead of relying
+# on the host's default_protect_from_forgery (load_defaults 5.2+).
 # Note: We're NOT skipping SQL injection checks - those should be reviewed
 # Note: We're NOT skipping file access checks - those should be reviewed

--- a/test/controllers/rails_pulse/csrf_protection_test.rb
+++ b/test/controllers/rails_pulse/csrf_protection_test.rb
@@ -1,0 +1,103 @@
+require "test_helper"
+
+# The dummy app (like every Rails test env) sets allow_forgery_protection =
+# false, so no other controller test exercises CSRF. These do, by flipping it
+# on for the duration of the test.
+class RailsPulse::CsrfProtectionTest < ActionDispatch::IntegrationTest
+  fixtures :rails_pulse_routes, :rails_pulse_deployments
+
+  DEPLOY_TOKEN = "csrf-test-deploy-token".freeze
+
+  def setup
+    ENV["TEST_TYPE"] = "functional"
+    @original_forgery = ActionController::Base.allow_forgery_protection
+    @original_token   = RailsPulse.configuration.deployment_api_token
+    ActionController::Base.allow_forgery_protection = true
+    RailsPulse.configuration.deployment_api_token = DEPLOY_TOKEN
+    super
+  end
+
+  def teardown
+    ActionController::Base.allow_forgery_protection = @original_forgery
+    RailsPulse.configuration.deployment_api_token = @original_token
+    super
+  end
+
+  # Structure Tests
+
+  test "the engine declares its own forgery protection strategy" do
+    strategy = RailsPulse::ApplicationController.forgery_protection_strategy
+
+    assert_equal ActionController::RequestForgeryProtection::ProtectionMethods::Exception, strategy
+  end
+
+  test "the strategy does not depend on the host's ActionController::Base default" do
+    # A host on load_defaults < 5.2 never calls protect_from_forgery on Base.
+    # Simulate that by weakening Base and checking the engine keeps its own.
+    original = ActionController::Base.forgery_protection_strategy
+    ActionController::Base.forgery_protection_strategy =
+      ActionController::RequestForgeryProtection::ProtectionMethods::NullSession
+
+    assert_equal ActionController::RequestForgeryProtection::ProtectionMethods::Exception,
+      RailsPulse::ApplicationController.forgery_protection_strategy
+  ensure
+    ActionController::Base.forgery_protection_strategy = original
+  end
+
+  test "verify_authenticity_token runs before authentication" do
+    filters = RailsPulse::ApplicationController._process_action_callbacks.map(&:filter)
+
+    assert_operator filters.index(:verify_authenticity_token), :<, filters.index(:authenticate_rails_pulse_user!)
+  end
+
+  # Request Tests
+
+  test "a state-changing request without a token is rejected" do
+    route = rails_pulse_routes(:api_users)
+
+    assert_no_changes -> { route.reload.tag_list } do
+      post rails_pulse.add_tag_path("route", route.id, tag: "forged")
+    end
+
+    assert_response :unprocessable_content
+  end
+
+  test "settings mutations without a token are rejected" do
+    patch rails_pulse.settings_time_range_path, params: { preset: "last_7_days" }
+
+    assert_response :unprocessable_content
+    assert_nil session[:time_range_preference]
+  end
+
+  test "a state-changing request with the page's token succeeds" do
+    route = rails_pulse_routes(:api_users)
+
+    get rails_pulse.route_path(route)
+
+    assert_response :success
+    token = css_select("meta[name=csrf-token]").first["content"]
+
+    post rails_pulse.add_tag_path("route", route.id, tag: "legit"),
+      headers: { "X-CSRF-Token" => token }
+
+    assert_response :redirect
+    assert_includes route.reload.tag_list, "legit"
+  end
+
+  test "GET requests are unaffected" do
+    get rails_pulse.root_path
+
+    assert_response :success
+  end
+
+  test "the token-authenticated deployments API stays exempt" do
+    assert_difference -> { RailsPulse::Deployment.count }, 1 do
+      post rails_pulse.deployments_path,
+        params: { deployment: { revision: "csrf-exempt" } },
+        headers: { "X-Rails-Pulse-Token" => DEPLOY_TOKEN },
+        as: :json
+    end
+
+    assert_response :created
+  end
+end


### PR DESCRIPTION
## Problem

`RailsPulse::ApplicationController < ActionController::Base`, and nothing in the engine calls `protect_from_forgery`. Rails only installs it on `Base` when `config.action_controller.default_protect_from_forgery` is true — which `load_defaults "5.2"` or later sets (`actionpack/lib/action_controller/railtie.rb`). A host still on an older `load_defaults` (long-lived apps upgraded incrementally are common), or one that set the flag false and relies on `protect_from_forgery` in its own `ApplicationController`, gets **no CSRF protection on any engine endpoint**: tag add/remove, exception status/preserve, query reanalyze, session filter and time-range mutation, pagination.

`config/brakeman.yml` skipped `CheckForgerySetting` with the note "CSRF protection is handled by host app" — the exact assumption that was wrong. And the dummy app runs with `allow_forgery_protection = false` like every Rails test env, so nothing could catch it.

## Fix

- `protect_from_forgery with: :exception` in `RailsPulse::ApplicationController`. Idempotent when the host already has it; `DeploymentsController` (`create`/`finish`) and `AssetsController` keep their explicit skips.
- Remove the `CheckForgerySetting` skip from `config/brakeman.yml`.

## Tests

New `csrf_protection_test.rb` turns `allow_forgery_protection` on for its duration and asserts:

- the engine's strategy is `Exception` and stays so even when `ActionController::Base` is weakened to `NullSession` (simulating a pre-5.2 host)
- `verify_authenticity_token` runs before `authenticate_rails_pulse_user!`
- token-less `POST /tags/…` and `PATCH /settings/time_range` are rejected with 422 and change nothing
- a `POST` carrying the page's `csrf-token` meta succeeds
- `GET` is unaffected
- the token-authenticated deployments API remains exempt

`DB=sqlite3 bin/rails test` on the controller suites: 136 runs, 0 failures. RuboCop clean. Brakeman reports the same two pre-existing `SQL` warnings before and after (stale `explain_plan_analyzer` fingerprint, `route_migrator` false positive) — no new forgery warning; those two get re-triaged in the EXPLAIN hardening PR.

Finding M1 from the security audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BaximWeiDUL64Mr5RXWi4n
