### PR TITLE
Fail closed on authentication hooks; harden EXPLAIN against multi-statement SQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on an older `load_defaults` had no CSRF protection on any engine endpoint (tags,
   exception status, query reanalyze, session filters). Brakeman's `CheckForgerySetting`
   is no longer skipped.
+- **Authentication hooks fail closed.** An `authentication_method` that returned
+  `false` without rendering or redirecting used to grant access — `proc { current_user&.admin? }`
+  looked right and let every non-admin in. Literal `false` is now a 403; `nil`
+  (what the documented `unless … redirect_to … end` style returns on success) still allows.
+- **EXPLAIN hardening.** The query analyzer now refuses SQL containing `;`, `--` or `/*`
+  anywhere (PostgreSQL's `execute` runs every statement in a string, so a captured
+  `SELECT …; UPDATE …` would have re-run the UPDATE on each page view), runs the
+  PostgreSQL EXPLAIN inside `SET LOCAL transaction_read_only = on` with a 5s
+  `statement_timeout` instead of `Timeout.timeout`, and always rolls its savepoint back.
 
 ### Added
 
 - **`exception_message_filter` config option** — an optional `->(message, exception)`
   hook applied after the built-in redaction for app-specific patterns. If the hook
   raises, the message is stored as `[FILTERED]` rather than unfiltered.
+- **`authorize` config option** — a fail-closed predicate, `->(controller) { … }`
+  (or a zero-argument proc run in the controller). Anything falsy is a 403. Runs after
+  `authentication_method` when both are set, and replaces the HTTP Basic fallback on
+  its own. This is now the recommended way to gate the dashboard.
 
 ## [0.4.0.pre.1] - 2026-08-29
 

--- a/README.md
+++ b/README.md
@@ -118,11 +118,20 @@ Full configuration reference: [railspulse.com/documentation/advanced](https://ra
 
 ## Authentication
 
-Rails Pulse has no built-in authentication, you protect the dashboard using your app's existing auth. Add an `authentication_method` to the initializer:
+Rails Pulse has no built-in user accounts; you protect the dashboard using your app's existing auth. Authentication is on by default outside development and test, and with nothing configured it falls back to HTTP Basic against `RAILS_PULSE_USERNAME` / `RAILS_PULSE_PASSWORD` (denying everything if the password is unset).
+
+The simplest hook is a predicate that receives the controller and returns `true` to allow — anything else is a 403:
 
 ```ruby
 RailsPulse.configure do |config|
-  config.authentication_enabled = true
+  config.authorize = ->(controller) { controller.current_user&.admin? }
+end
+```
+
+If you need to redirect to a login page instead, use `authentication_method`, which runs inside the controller and denies by rendering or redirecting:
+
+```ruby
+RailsPulse.configure do |config|
   config.authentication_redirect_path = "/login"
 
   config.authentication_method = proc {
@@ -132,6 +141,8 @@ RailsPulse.configure do |config|
   }
 end
 ```
+
+Returning `false` from `authentication_method` without responding is also treated as a denial, but `nil` (what `unless … end` returns on success) allows the request — so keep predicate-style checks in `authorize`.
 
 Authentication guide: [railspulse.com/documentation/authentication](https://railspulse.com/documentation/authentication)
 

--- a/app/controllers/rails_pulse/application_controller.rb
+++ b/app/controllers/rails_pulse/application_controller.rb
@@ -90,33 +90,65 @@ module RailsPulse
       RailsPulse.logger
     end
 
+    # Two hooks, run in order:
+    #
+    # * `authentication_method` — the legacy hook. It denies by rendering or
+    #   redirecting (the documented `unless signed_in? then redirect_to`
+    #   style). Returning literal `false` without responding is also a
+    #   denial; returning nil (which `unless … end` does on success) allows.
+    # * `authorize` — a fail-closed predicate. Anything falsy is a 403.
+    #
+    # With neither configured, HTTP Basic against RAILS_PULSE_PASSWORD.
     def authenticate_rails_pulse_user!
-      return unless RailsPulse.configuration.authentication_enabled
+      config = RailsPulse.configuration
+      return unless config.authentication_enabled
 
-      # If no authentication method is configured, use fallback HTTP Basic Auth
-      if RailsPulse.configuration.authentication_method.nil?
+      if config.authentication_method.nil? && config.authorize.nil?
         return fallback_http_basic_auth
       end
 
-      # Safely execute authentication method in controller context
-      case RailsPulse.configuration.authentication_method
-      when Proc
-        instance_exec(&RailsPulse.configuration.authentication_method)
-      when Symbol, String
-        method_name = RailsPulse.configuration.authentication_method.to_s
-        if respond_to?(method_name, true)
-          send(method_name)
-        else
-          logger.error "RailsPulse: Authentication method '#{method_name}' not found"
-          render plain: "Authentication configuration error", status: :internal_server_error
-        end
-      else
-        logger.error "RailsPulse: Invalid authentication method type: #{RailsPulse.configuration.authentication_method.class}"
-        render plain: "Authentication configuration error", status: :internal_server_error
+      unless config.authentication_method.nil?
+        run_authentication_method(config.authentication_method)
+        return if performed?
       end
+
+      run_authorize_predicate(config.authorize) if config.authorize
     rescue StandardError => e
       logger.warn "RailsPulse authentication failed: #{e.message}"
-      redirect_to RailsPulse.configuration.authentication_redirect_path
+      redirect_to config.authentication_redirect_path
+    end
+
+    def run_authentication_method(hook)
+      result = case hook
+      when Proc
+        instance_exec(&hook)
+      when Symbol, String
+        method_name = hook.to_s
+        unless respond_to?(method_name, true)
+          logger.error "RailsPulse: Authentication method '#{method_name}' not found"
+          return render plain: "Authentication configuration error", status: :internal_server_error
+        end
+        send(method_name)
+      else
+        logger.error "RailsPulse: Invalid authentication method type: #{hook.class}"
+        return render plain: "Authentication configuration error", status: :internal_server_error
+      end
+
+      return if performed?
+      return unless result == false
+
+      # `proc { current_user&.admin? }` reads as a predicate but never halts
+      # the chain. Treat an explicit false as the denial it was meant to be.
+      logger.warn "RailsPulse: authentication_method returned false without rendering or redirecting; " \
+                  "denying access. Use config.authorize for predicate-style checks."
+      render plain: "Forbidden", status: :forbidden
+    end
+
+    def run_authorize_predicate(predicate)
+      allowed = predicate.arity.zero? ? instance_exec(&predicate) : predicate.call(self)
+      return if allowed
+
+      render plain: "Forbidden", status: :forbidden
     end
 
     def fallback_http_basic_auth

--- a/app/services/rails_pulse/analysis/explain_plan_analyzer.rb
+++ b/app/services/rails_pulse/analysis/explain_plan_analyzer.rb
@@ -3,12 +3,21 @@
 module RailsPulse
   module Analysis
     class ExplainPlanAnalyzer < BaseAnalyzer
-      EXPLAIN_TIMEOUT = 5.seconds
+      # PostgreSQL statement_timeout for the EXPLAIN itself. Planner-only
+      # work is fast; this only guards against a pathological plan.
+      STATEMENT_TIMEOUT = "5s".freeze
 
       # Only EXPLAIN SELECT/WITH statements — executing EXPLAIN on a
       # DELETE/UPDATE/INSERT would re-run the statement on PostgreSQL
       # when ANALYZE is used, and is never useful for the dashboard.
       SAFE_VERB = /\A\s*(SELECT|WITH)\b/i
+
+      # The verb check only sees the first statement. PostgreSQL's execute
+      # (async_exec) runs every statement in the string, so a captured
+      # "SELECT …; UPDATE …" would re-run the UPDATE on every page view.
+      # Comments are refused too: nothing legitimate needs them explained,
+      # and they are the other place a second statement can hide.
+      UNSAFE_SQL = %r{;|--|/\*}
 
       def analyze
         return { explain_plan: nil, issues: [] } if recent_operations.empty?
@@ -28,27 +37,32 @@ module RailsPulse
         return nil unless sql.present?
         return nil unless sql.match?(SAFE_VERB)
 
-        begin
-          sanitized_sql = sanitize_sql_for_explain(sql)
-          conn = RailsPulse::ApplicationRecord.connection
+        sanitized_sql = sanitize_sql_for_explain(sql)
+        return nil unless sanitized_sql
 
-          # Wrap in a savepoint so that a failed EXPLAIN on PostgreSQL does not
-          # abort the surrounding transaction (e.g. during tests or inside a
-          # host app's transaction block).
+        begin
+          conn = RailsPulse::ApplicationRecord.connection
+          plan = nil
+
+          # A savepoint keeps a failed EXPLAIN from aborting the host's
+          # surrounding transaction, and it is always rolled back: EXPLAIN
+          # writes nothing, so rolling back costs nothing, and it undoes the
+          # SET LOCALs below (and anything a statement that slipped past the
+          # guards might have done) instead of leaking them into the caller's
+          # transaction.
           conn.transaction(requires_new: true) do
-            Timeout.timeout(EXPLAIN_TIMEOUT) do
-              case database_adapter
-              when "postgresql"
-                execute_postgres_explain(sanitized_sql)
-              when "mysql", "mysql2"
-                execute_mysql_explain(sanitized_sql)
-              when "sqlite"
-                execute_sqlite_explain(sanitized_sql)
-              else
-                nil
-              end
+            plan = case database_adapter
+            when "postgresql"
+              execute_postgres_explain(sanitized_sql)
+            when "mysql", "mysql2"
+              execute_mysql_explain(sanitized_sql)
+            when "sqlite"
+              execute_sqlite_explain(sanitized_sql)
             end
+            raise ActiveRecord::Rollback
           end
+
+          plan
         rescue => e
           RailsPulse.logger.warn("[ExplainPlanAnalyzer] EXPLAIN failed for query #{query.id}: #{e.message}")
           nil
@@ -191,13 +205,25 @@ module RailsPulse
         issues
       end
 
+      # Strips a trailing terminator, then refuses anything that could still
+      # carry a second statement or a comment. Returns nil for refused SQL.
       def sanitize_sql_for_explain(sql)
-        # Basic sanitization for EXPLAIN
-        sql.strip.gsub(/;+\s*$/, "")
+        cleaned = sql.strip.gsub(/;+\s*$/, "")
+        return nil if cleaned.match?(UNSAFE_SQL)
+
+        cleaned
       end
 
+      # SET LOCAL is scoped to the enclosing transaction/savepoint and is
+      # undone by the rollback in generate_explain_plan. Read-only means
+      # even a statement that got past the guards cannot write, and the
+      # timeout replaces Timeout.timeout, which could interrupt the driver
+      # mid-protocol and leave the connection in an undefined state.
       def execute_postgres_explain(sql)
-        result = RailsPulse::ApplicationRecord.connection.execute("EXPLAIN #{sql}")
+        conn = RailsPulse::ApplicationRecord.connection
+        conn.execute("SET LOCAL transaction_read_only = on")
+        conn.execute("SET LOCAL statement_timeout = '#{STATEMENT_TIMEOUT}'")
+        result = conn.execute("EXPLAIN #{sql}")
         result.values.flatten.join("\n")
       end
 

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -138,73 +138,96 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "3c816cd9f565d6592595f5566cbd9d9a19ecb51ad704477f01a9bf2b4c1f29fb",
       "check_name": "SQL",
       "message": "Possible SQL injection",
-      "file": "app/services/rails_pulse/analysis/explain_plan_analyzer.rb",
-      "line": 191,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "RailsPulse::ApplicationRecord.connection.execute(\"EXPLAIN (ANALYZE, BUFFERS) #{sql}\")",
       "render_path": null,
+      "user_input": "sql",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "fingerprint": "becdaa493e66ef0e0bf0dc57eadcdaa621ef870b8bcacbcf4ee96fd5ff3d6e0c",
+      "file": "app/services/rails_pulse/analysis/explain_plan_analyzer.rb",
+      "line": 226,
+      "code": "RailsPulse::ApplicationRecord.connection.execute(\"EXPLAIN #{sql}\")",
       "location": {
         "type": "method",
         "class": "RailsPulse::Analysis::ExplainPlanAnalyzer",
         "method": "execute_postgres_explain"
       },
-      "user_input": "sql",
-      "confidence": "Medium",
-      "cwe_id": [
-        89
-      ],
-      "note": "Reviewed: EXPLAIN (without ANALYZE) is planner-only on all adapters. Only SELECT/WITH statements are passed \u2014 non-SELECT verbs are rejected by SAFE_VERB check."
+      "note": "Reviewed: planner-only EXPLAIN (no ANALYZE). Input is SQL captured from the host app, gated by SAFE_VERB (SELECT/WITH only) and UNSAFE_SQL (refuses ';', '--', '/*' so no second statement or comment can ride along). Runs inside a savepoint that is always rolled back; on PostgreSQL also under SET LOCAL transaction_read_only = on with a statement_timeout."
     },
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "85c09ca9672d132fb206d0371e20087deaf381d89733f73d647129878b89f374",
       "check_name": "SQL",
       "message": "Possible SQL injection",
-      "file": "app/services/rails_pulse/analysis/explain_plan_analyzer.rb",
-      "line": 201,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "RailsPulse::ApplicationRecord.connection.execute(\"EXPLAIN QUERY PLAN #{sql}\")",
       "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "RailsPulse::Analysis::ExplainPlanAnalyzer",
-        "method": "execute_sqlite_explain"
-      },
       "user_input": "sql",
       "confidence": "Medium",
       "cwe_id": [
         89
       ],
-      "note": "Reviewed: EXPLAIN QUERY PLAN is planner-only on SQLite. Only SELECT/WITH statements are passed \u2014 non-SELECT verbs are rejected by SAFE_VERB check."
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
       "fingerprint": "a57a1c949d21de15d6b48e52bfc3077e3177a13ba1d703ddf48e241fb4e81c6e",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
       "file": "app/services/rails_pulse/analysis/explain_plan_analyzer.rb",
-      "line": 196,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "line": 231,
       "code": "RailsPulse::ApplicationRecord.connection.execute(\"EXPLAIN #{sql}\")",
-      "render_path": null,
       "location": {
         "type": "method",
         "class": "RailsPulse::Analysis::ExplainPlanAnalyzer",
         "method": "execute_mysql_explain"
       },
+      "note": "Reviewed: planner-only EXPLAIN (no ANALYZE). Input is SQL captured from the host app, gated by SAFE_VERB (SELECT/WITH only) and UNSAFE_SQL (refuses ';', '--', '/*' so no second statement or comment can ride along). Runs inside a savepoint that is always rolled back; on PostgreSQL also under SET LOCAL transaction_read_only = on with a statement_timeout."
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "render_path": null,
       "user_input": "sql",
       "confidence": "Medium",
       "cwe_id": [
         89
       ],
-      "note": "Reviewed: EXPLAIN is planner-only on all adapters. Only SELECT/WITH statements are passed \u2014 non-SELECT verbs are rejected by SAFE_VERB check."
+      "fingerprint": "85c09ca9672d132fb206d0371e20087deaf381d89733f73d647129878b89f374",
+      "file": "app/services/rails_pulse/analysis/explain_plan_analyzer.rb",
+      "line": 236,
+      "code": "RailsPulse::ApplicationRecord.connection.execute(\"EXPLAIN QUERY PLAN #{sql}\")",
+      "location": {
+        "type": "method",
+        "class": "RailsPulse::Analysis::ExplainPlanAnalyzer",
+        "method": "execute_sqlite_explain"
+      },
+      "note": "Reviewed: planner-only EXPLAIN (no ANALYZE). Input is SQL captured from the host app, gated by SAFE_VERB (SELECT/WITH only) and UNSAFE_SQL (refuses ';', '--', '/*' so no second statement or comment can ride along). Runs inside a savepoint that is always rolled back; on PostgreSQL also under SET LOCAL transaction_read_only = on with a statement_timeout."
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "render_path": null,
+      "user_input": "RailsPulse::Route.maximum(:id).to_i",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "fingerprint": "34a13be0814c310f2cbd905920970ee397e824b5d0a8afdc226c5f02ab18d1c6",
+      "file": "app/services/rails_pulse/route_migrator.rb",
+      "line": 122,
+      "code": "RailsPulse::Route.connection.execute(\"ALTER TABLE #{RailsPulse::Route.connection.quote_table_name(RailsPulse::Route.table_name)} AUTO_INCREMENT = #{(RailsPulse::Route.maximum(:id).to_i + 1)}\")",
+      "location": {
+        "type": "method",
+        "class": "RailsPulse::RouteMigrator",
+        "method": "sync_id_sequence!"
+      },
+      "note": "Reviewed: table name goes through quote_table_name and the only interpolated value is an Integer (maximum(:id).to_i + 1). Rake-task only, no user input."
     }
   ],
-  "updated": "2026-04-14 21:59:41 +0700",
+  "updated": "2026-09-01 14:14:15 +0700",
   "brakeman_version": "7.1.1"
 }

--- a/lib/generators/rails_pulse/templates/rails_pulse.rb
+++ b/lib/generators/rails_pulse/templates/rails_pulse.rb
@@ -249,21 +249,30 @@ RailsPulse.configure do |config|
   #                                            AUTHENTICATION
   # ====================================================================================================
   # Configure authentication to secure access to the Rails Pulse dashboard.
-  # Authentication is ENABLED BY DEFAULT in production environments for security.
+  # Authentication is ENABLED BY DEFAULT outside development and test.
   #
-  # If no authentication method is configured, Rails Pulse will use HTTP Basic Auth
+  # If nothing below is configured, Rails Pulse will use HTTP Basic Auth
   # with credentials from RAILS_PULSE_USERNAME (default: 'admin') and RAILS_PULSE_PASSWORD
   # environment variables. Set RAILS_PULSE_PASSWORD to enable this fallback.
-  #
-  # Uncomment and configure one of the following patterns based on your authentication system:
 
-  # Enable/disable authentication (enabled by default in production)
-  # config.authentication_enabled = Rails.env.production?
+  # Enable/disable authentication (enabled by default outside development/test)
+  # config.authentication_enabled = !Rails.env.local?
 
-  # Where to redirect unauthorized users
+  # Where to redirect users when an authentication hook raises
   # config.authentication_redirect_path = "/"
 
-  # Custom authentication method - choose one of the examples below:
+  # RECOMMENDED: a fail-closed predicate. Receives the controller; return
+  # true to allow. Anything else (false, nil, no user) is a 403 Forbidden.
+  # config.authorize = ->(controller) { controller.current_user&.admin? }
+  #
+  # A zero-argument proc runs in the controller's context instead:
+  # config.authorize = proc { user_signed_in? && current_user.admin? }
+
+  # Alternatively, a hook that runs in the controller and DENIES BY RENDERING
+  # OR REDIRECTING. Returning false without responding is also a denial;
+  # returning nil (what `unless … end` returns on success) allows the request.
+  # Do not write predicate-style checks here — use config.authorize for those.
+  # If both are set, authentication_method runs first, then authorize.
 
   # Example 1: Devise with admin role check
   # config.authentication_method = proc {

--- a/lib/rails_pulse/configuration.rb
+++ b/lib/rails_pulse/configuration.rb
@@ -20,6 +20,7 @@ module RailsPulse
                   :connects_to,
                   :authentication_enabled,
                   :authentication_method,
+                  :authorize,
                   :authentication_redirect_path,
                   :tags,
                   :job_tracking_mode,
@@ -99,6 +100,9 @@ module RailsPulse
       @authentication_enabled = !(Rails.env.development? || Rails.env.test?)
       @authentication_enabled_explicitly_set = false
       @authentication_method = nil
+      # Fail-closed predicate: ->(controller) { true to allow }. Anything
+      # falsy is a 403. Runs after authentication_method, if both are set.
+      @authorize = nil
       @authentication_redirect_path = "/"
       @tags = [ "ignored", "critical", "experimental" ]
       @job_tracking_mode = :universal
@@ -310,12 +314,16 @@ module RailsPulse
     end
 
     def validate_authentication_settings!
-      if @authentication_enabled && @authentication_enabled_explicitly_set && @authentication_method.nil?
+      if @authentication_enabled && @authentication_enabled_explicitly_set && @authentication_method.nil? && @authorize.nil?
         RailsPulse.logger.warn "Authentication is enabled but no authentication method is configured. This will deny all access."
       end
 
       if @authentication_method && ![ Proc, Symbol, String ].include?(@authentication_method.class)
         raise ArgumentError, "authentication_method must be a Proc, Symbol, String, or nil, got #{@authentication_method.class}"
+      end
+
+      if @authorize && !@authorize.respond_to?(:call)
+        raise ArgumentError, "authorize must respond to #call (a proc or lambda receiving the controller and returning true to allow), got #{@authorize.class}"
       end
     end
 

--- a/test/controllers/rails_pulse/application_controller_test.rb
+++ b/test/controllers/rails_pulse/application_controller_test.rb
@@ -318,6 +318,148 @@ class RailsPulse::ApplicationControllerTest < ActionDispatch::IntegrationTest
     assert_match "Invalid token", response.body
   end
 
+  # Fail-closed Hook Semantics
+
+  test "authentication denies when the Proc returns false without responding" do
+    # `proc { current_user&.admin? }` for a non-admin. Before this was
+    # enforced, the request went straight through.
+    auth_proc = proc { false }
+
+    RailsPulse.configuration.stubs(:authentication_enabled).returns(true)
+    RailsPulse.configuration.stubs(:authentication_method).returns(auth_proc)
+    RailsPulse.configuration.stubs(:authorize).returns(nil)
+
+    get rails_pulse.root_path
+
+    assert_response :forbidden
+  end
+
+  test "authentication allows when the Proc returns nil without responding" do
+    # The documented `unless signed_in? then redirect_to … end` style returns
+    # nil on success; that must keep working.
+    auth_proc = proc { redirect_to "/login" unless true }
+
+    RailsPulse.configuration.stubs(:authentication_enabled).returns(true)
+    RailsPulse.configuration.stubs(:authentication_method).returns(auth_proc)
+    RailsPulse.configuration.stubs(:authorize).returns(nil)
+
+    get rails_pulse.root_path
+
+    assert_response :success
+  end
+
+  test "authentication denies when a Symbol method returns false without responding" do
+    RailsPulse::ApplicationController.class_eval do
+      def predicate_style_auth
+        false
+      end
+    end
+
+    RailsPulse.configuration.stubs(:authentication_enabled).returns(true)
+    RailsPulse.configuration.stubs(:authentication_method).returns(:predicate_style_auth)
+    RailsPulse.configuration.stubs(:authorize).returns(nil)
+
+    get rails_pulse.root_path
+
+    assert_response :forbidden
+  ensure
+    RailsPulse::ApplicationController.send(:remove_method, :predicate_style_auth) if RailsPulse::ApplicationController.method_defined?(:predicate_style_auth)
+  end
+
+  # authorize Predicate
+
+  test "authorize allows when the predicate is truthy" do
+    RailsPulse.configuration.stubs(:authentication_enabled).returns(true)
+    RailsPulse.configuration.stubs(:authentication_method).returns(nil)
+    RailsPulse.configuration.stubs(:authorize).returns(->(controller) { controller.params[:role] == "admin" })
+
+    get rails_pulse.root_path, params: { role: "admin" }
+
+    assert_response :success
+  end
+
+  test "authorize denies when the predicate is false" do
+    RailsPulse.configuration.stubs(:authentication_enabled).returns(true)
+    RailsPulse.configuration.stubs(:authentication_method).returns(nil)
+    RailsPulse.configuration.stubs(:authorize).returns(->(controller) { controller.params[:role] == "admin" })
+
+    get rails_pulse.root_path, params: { role: "viewer" }
+
+    assert_response :forbidden
+  end
+
+  test "authorize denies when the predicate is nil" do
+    # current_user&.admin? with no signed-in user.
+    RailsPulse.configuration.stubs(:authentication_enabled).returns(true)
+    RailsPulse.configuration.stubs(:authentication_method).returns(nil)
+    RailsPulse.configuration.stubs(:authorize).returns(->(_controller) { nil })
+
+    get rails_pulse.root_path
+
+    assert_response :forbidden
+  end
+
+  test "authorize runs a zero-arity proc in the controller context" do
+    RailsPulse.configuration.stubs(:authentication_enabled).returns(true)
+    RailsPulse.configuration.stubs(:authentication_method).returns(nil)
+    RailsPulse.configuration.stubs(:authorize).returns(proc { params[:role] == "admin" })
+
+    get rails_pulse.root_path, params: { role: "admin" }
+
+    assert_response :success
+  end
+
+  test "authorize alone does not fall back to HTTP Basic" do
+    ENV["RAILS_PULSE_PASSWORD"] = nil
+    RailsPulse.configuration.stubs(:authentication_enabled).returns(true)
+    RailsPulse.configuration.stubs(:authentication_method).returns(nil)
+    RailsPulse.configuration.stubs(:authorize).returns(->(_c) { true })
+
+    get rails_pulse.root_path
+
+    assert_response :success
+  end
+
+  test "authorize is skipped when authentication_method already responded" do
+    RailsPulse.configuration.stubs(:authentication_enabled).returns(true)
+    RailsPulse.configuration.stubs(:authentication_method).returns(proc { redirect_to "/login" })
+    RailsPulse.configuration.stubs(:authorize).returns(->(_c) { true })
+
+    get rails_pulse.root_path
+
+    assert_redirected_to "/login"
+  end
+
+  test "authorize runs after an authentication_method that allowed" do
+    RailsPulse.configuration.stubs(:authentication_enabled).returns(true)
+    RailsPulse.configuration.stubs(:authentication_method).returns(proc { @signed_in = true })
+    RailsPulse.configuration.stubs(:authorize).returns(->(_c) { false })
+
+    get rails_pulse.root_path
+
+    assert_response :forbidden
+  end
+
+  test "authorize raising is rescued and redirects" do
+    RailsPulse.configuration.stubs(:authentication_enabled).returns(true)
+    RailsPulse.configuration.stubs(:authentication_method).returns(nil)
+    RailsPulse.configuration.stubs(:authorize).returns(->(_c) { raise "boom" })
+    RailsPulse.configuration.stubs(:authentication_redirect_path).returns("/login")
+
+    get rails_pulse.root_path
+
+    assert_redirected_to "/login"
+  end
+
+  test "authorize is not consulted when authentication is disabled" do
+    RailsPulse.configuration.stubs(:authentication_enabled).returns(false)
+    RailsPulse.configuration.stubs(:authorize).returns(->(_c) { false })
+
+    get rails_pulse.root_path
+
+    assert_response :success
+  end
+
   # set_global_filters Tests
 
   test "set_global_filters clears filters when clear param is true" do

--- a/test/controllers/rails_pulse/deployments_controller_test.rb
+++ b/test/controllers/rails_pulse/deployments_controller_test.rb
@@ -82,6 +82,22 @@ class RailsPulse::DeploymentsControllerTest < ActionDispatch::IntegrationTest
     assert_response :created
   end
 
+  test "the API falls back to the authorize predicate when no token is configured" do
+    RailsPulse.configuration.deployment_api_token = nil
+    RailsPulse.configuration.stubs(:authentication_enabled).returns(true)
+    RailsPulse.configuration.stubs(:authentication_method).returns(nil)
+    RailsPulse.configuration.stubs(:authorize).returns(->(_controller) { false })
+
+    assert_no_difference -> { RailsPulse::Deployment.count } do
+      post rails_pulse.deployments_path,
+        params: { deployment: { revision: "denied" } },
+        headers: {},
+        as: :json
+    end
+
+    assert_response :forbidden
+  end
+
   test "index renders deployment status" do
     get rails_pulse.deployments_path
 

--- a/test/lib/rails_pulse/configuration_test.rb
+++ b/test/lib/rails_pulse/configuration_test.rb
@@ -280,6 +280,34 @@ module RailsPulse
       assert_nothing_raised { config.validate_configuration! }
     end
 
+    test "authorize defaults to nil" do
+      assert_nil Configuration.new.authorize
+    end
+
+    test "validate_configuration! accepts a callable authorize" do
+      config = build_config { self.authorize = ->(controller) { controller.present? } }
+
+      assert_respond_to config.authorize, :call
+    end
+
+    test "validate_configuration! raises for a non-callable authorize" do
+      config = Configuration.new
+      config.authorize = true
+
+      error = assert_raises(ArgumentError) { config.validate_configuration! }
+      assert_match "authorize", error.message
+    end
+
+    test "validate_authentication_settings! does not warn when authorize is configured" do
+      config = Configuration.new
+      config.authentication_enabled = true
+      config.authorize = ->(_controller) { true }
+
+      RailsPulse.logger.expects(:warn).never
+
+      config.validate_configuration!
+    end
+
     test "validate_configuration! raises for SLO entry missing percentile key" do
       config = Configuration.new
       config.instance_variable_set(:@service_level_objectives, [ { threshold: 200 } ])

--- a/test/services/rails_pulse/analysis/explain_plan_analyzer_test.rb
+++ b/test/services/rails_pulse/analysis/explain_plan_analyzer_test.rb
@@ -85,6 +85,78 @@ module RailsPulse
         assert_nil result[:explain_plan]
       end
 
+      test "refuses to EXPLAIN multi-statement SQL even when it starts with SELECT" do
+        op = create_operation(actual_sql: "SELECT 1; DELETE FROM users")
+        analyzer = ExplainPlanAnalyzer.new(@query, [ op ])
+        RailsPulse::ApplicationRecord.connection.expects(:execute).never
+
+        result = analyzer.analyze
+
+        assert_nil result[:explain_plan]
+      end
+
+      test "refuses to EXPLAIN SQL containing comments" do
+        [ "SELECT 1 -- ; DELETE FROM users", "SELECT /* ; DELETE */ 1" ].each do |sql|
+          analyzer = ExplainPlanAnalyzer.new(@query, [ create_operation(actual_sql: sql) ])
+
+          assert_nil analyzer.analyze[:explain_plan], "expected #{sql.inspect} to be refused"
+        end
+      end
+
+      # Fake connection that records every statement and honours the
+      # savepoint contract (ActiveRecord::Rollback is swallowed).
+      class RecordingConnection
+        attr_reader :executed, :rolled_back
+
+        def initialize(adapter_name)
+          @adapter_name = adapter_name
+          @executed = []
+          @rolled_back = false
+        end
+
+        attr_reader :adapter_name
+
+        def transaction(requires_new: false)
+          yield
+        rescue ActiveRecord::Rollback
+          @rolled_back = true
+          nil
+        end
+
+        def execute(sql)
+          @executed << sql
+          Struct.new(:values, :to_a).new([ [ "Seq Scan on users" ] ], [ { "plan" => "Seq Scan on users" } ])
+        end
+      end
+
+      test "postgres EXPLAIN runs read-only with a statement timeout and rolls the savepoint back" do
+        conn = RecordingConnection.new("PostgreSQL")
+        RailsPulse::ApplicationRecord.stubs(:connection).returns(conn)
+        analyzer = ExplainPlanAnalyzer.new(@query, [ create_operation(actual_sql: "SELECT * FROM users;") ])
+
+        result = analyzer.analyze
+
+        assert_equal [
+          "SET LOCAL transaction_read_only = on",
+          "SET LOCAL statement_timeout = '5s'",
+          "EXPLAIN SELECT * FROM users"
+        ], conn.executed
+        assert conn.rolled_back, "the EXPLAIN savepoint must be rolled back so SET LOCAL does not leak"
+        assert_equal "Seq Scan on users", result[:explain_plan]
+      end
+
+      test "mysql EXPLAIN rolls the savepoint back" do
+        conn = RecordingConnection.new("Mysql2")
+        RailsPulse::ApplicationRecord.stubs(:connection).returns(conn)
+        analyzer = ExplainPlanAnalyzer.new(@query, [ create_operation(actual_sql: "SELECT * FROM users") ])
+
+        result = analyzer.analyze
+
+        assert_equal [ "EXPLAIN SELECT * FROM users" ], conn.executed
+        assert conn.rolled_back
+        assert_equal "Seq Scan on users", result[:explain_plan]
+      end
+
       # ============================================================================
       # Sequential Scan Detection Tests
       # ============================================================================
@@ -416,6 +488,19 @@ module RailsPulse
         sanitized = analyzer.send(:sanitize_sql_for_explain, sql)
 
         assert_equal "SELECT * FROM users WHERE id = 1", sanitized
+      end
+
+      test "sanitize_sql_for_explain refuses an embedded semicolon" do
+        analyzer = TestExplainPlanAnalyzer.new(@query, [ create_operation ])
+
+        assert_nil analyzer.send(:sanitize_sql_for_explain, "SELECT 1; DELETE FROM users;")
+      end
+
+      test "sanitize_sql_for_explain refuses line and block comments" do
+        analyzer = TestExplainPlanAnalyzer.new(@query, [ create_operation ])
+
+        assert_nil analyzer.send(:sanitize_sql_for_explain, "SELECT 1 -- trailing")
+        assert_nil analyzer.send(:sanitize_sql_for_explain, "SELECT /* hidden */ 1")
       end
 
       test "sanitize_sql_for_explain strips leading and trailing whitespace" do


### PR DESCRIPTION
Two fail-closed fixes from the security audit (M2 and M3), plus the Brakeman re-triage promised in #216.

## M2 — authentication hooks fail open on a falsy return

`authenticate_rails_pulse_user!` did `instance_exec(&authentication_method)` and discarded the result. A hook that returned `false` without rendering or redirecting granted access. `proc { current_user&.admin? }` reads as a predicate, looks correct, and let every non-admin **and every anonymous visitor** (`nil`) in. `DeploymentsController` inherited the hole when no `deployment_api_token` was set. The test suite covered "hook renders 401" and "hook raises", never "hook returns false".

**Fix**

- **`config.authorize`** — a fail-closed predicate: `->(controller) { controller.current_user&.admin? }`, or a zero-argument proc run in the controller. Anything falsy → 403. Runs after `authentication_method` when both are set; on its own it replaces the HTTP Basic fallback. Template and README now lead with it.
- `authentication_method` returning **literal `false`** without responding is now a 403 (with a log line pointing at `authorize`). `nil` — what the documented `unless … redirect_to … end` style returns on success — still allows, so existing redirect-style hooks are untouched. Treating `nil` as denial would have broken every documented example, which is why the predicate is a separate option.

## M3 — EXPLAIN runs captured host SQL with no multi-statement guard

`SAFE_VERB` only checked the first statement and `sanitize_sql_for_explain` only stripped *trailing* semicolons. PostgreSQL's `execute` is `async_exec`, which runs every statement in the string — a host that ever issued `execute("SELECT …; UPDATE …")` would have had the UPDATE re-run on every visit to that query's page, and on demand via `POST /queries/:id/reanalyze`. It also ran read-write, under `Timeout.timeout`, which can interrupt the driver mid-protocol.

**Fix**

- Refuse SQL containing `;`, `--` or `/*` anywhere (plan is `nil`, nothing is sent to the DB).
- PostgreSQL: `SET LOCAL transaction_read_only = on` + `SET LOCAL statement_timeout = '5s'` inside the savepoint; `Timeout.timeout` removed.
- The savepoint is now **always rolled back** — EXPLAIN writes nothing, so it's free, and it guarantees the `SET LOCAL`s don't leak into a host transaction (a released savepoint would have made the caller's transaction read-only for its remainder).

MySQL (multi-statements off by default) and SQLite (driver runs one statement) were not affected by the multi-statement issue; they get the `;`/comment refusal and the rollback.

## Brakeman

`rake brakeman` was already red on `main`: the PostgreSQL EXPLAIN ignore fingerprint was stale since ANALYZE was removed, and `route_migrator.rb:122` (`quote_table_name` + an Integer) was never triaged. Re-triaged all three EXPLAIN entries with accurate notes and added the migrator one. Green now.

## Tests

- `application_controller_test`: hook returns `false` → 403; hook returns `nil` → allowed; Symbol hook returning `false` → 403; `authorize` truthy/false/nil; zero-arity proc in controller context; no Basic fallback; skipped when `authentication_method` already responded; runs after an allowing hook; raising is rescued; ignored when auth is disabled.
- `deployments_controller_test`: token unset + `authorize` refusing → 403, nothing created.
- `configuration_test`: default, callable accepted, non-callable rejected, no boot warning when `authorize` is set.
- `explain_plan_analyzer_test`: `SELECT 1; DELETE FROM users` never reaches `execute`; comments refused; a recording fake connection asserts the exact PostgreSQL statement sequence and that the savepoint was rolled back; same rollback on MySQL.

`DB=sqlite3 bin/rails test` on the touched suites: 307 runs, 0 failures. RuboCop clean. `rake brakeman` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BaximWeiDUL64Mr5RXWi4n
