### PR TITLE
Low-severity hardening from the security audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `SELECT …; UPDATE …` would have re-run the UPDATE on each page view), runs the
   PostgreSQL EXPLAIN inside `SET LOCAL transaction_read_only = on` with a 5s
   `statement_timeout` instead of `Timeout.timeout`, and always rolls its savepoint back.
+- **Deployments API input is bounded.** `revision` is capped at 255 characters,
+  serialized `metadata` at 4 KB, and `started_at` may be at most one hour in the future
+  (a forged future marker would have stamped every later exception with a revision
+  that never shipped). `rails_pulse_deployments` now has a count cap
+  (`max_table_records`, default 1 000) enforced by `CleanupService`; deployments are
+  never pruned by age.
+- **Backtrace source snippets are limited to `app/`, `lib/` and `config/routes.rb`**
+  (`.rb`, `.erb`, `.rake`, `.haml`, `.slim`, `.jbuilder`). Previously any file under
+  `Rails.root` was readable through a backtrace frame, including initializers with
+  inline keys, `config/database.yml`, and `.env`.
+- **Standalone dashboard session cookie is `Secure` in production** (override with
+  `RAILS_PULSE_INSECURE_SESSION=1`). The rackup's "no Rails app" branch, which could
+  never boot (`NameError: uninitialized constant Rails`), is replaced with a clear
+  error; the deployment docs now give the working invocation.
 
 ### Added
 
@@ -43,6 +57,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (or a zero-argument proc run in the controller). Anything falsy is a 403. Runs after
   `authentication_method` when both are set, and replaces the HTTP Basic fallback on
   its own. This is now the recommended way to gate the dashboard.
+
+### Fixed
+
+- **Tag filters work on SQLite for tags containing `_`.** The `LIKE` patterns were
+  escaped but issued without an `ESCAPE` clause; SQLite has no default escape
+  character, so `my_tag` never matched and "hide records tagged my_tag" hid nothing.
+  All three adapters now get an explicit `ESCAPE '!'`.
+- **Hand-edited query strings no longer 500.** `?q=string`, unparseable custom date
+  ranges, unparseable `occurred_at` filters, a non-array `enabled_tags`, and
+  oversized or unparseable session time filters all fall back to defaults instead of
+  raising. Session-stored presets and performance thresholds are validated against
+  the known values.
 
 ## [0.4.0.pre.1] - 2026-08-29
 

--- a/app/controllers/concerns/chart_table_concern.rb
+++ b/app/controllers/concerns/chart_table_concern.rb
@@ -53,7 +53,7 @@ module ChartTableConcern
   end
 
   def setup_chart_and_table_data
-    ransack_params = params[:q] || {}
+    ransack_params = self.ransack_params
 
     unless partial_request?
       # Setup chart data first using original time range (no sorting from table)

--- a/app/controllers/concerns/ransack_params_concern.rb
+++ b/app/controllers/concerns/ransack_params_concern.rb
@@ -1,0 +1,18 @@
+# RansackParamsConcern
+#
+# Every filterable page reads its Ransack conditions from params[:q]. The
+# dashboard's own forms always send a hash, but a hand-edited URL can make it
+# a string or an array (`?q=foo`), and each caller would then invoke Hash
+# methods on it and 500. Normalise once, here.
+module RansackParamsConcern
+  extend ActiveSupport::Concern
+
+  private
+
+  # params[:q] as an ActionController::Parameters hash, or an empty one when
+  # the value is absent or not hash-shaped.
+  def ransack_params
+    q = params[:q]
+    q.respond_to?(:permit) ? q : ActionController::Parameters.new({})
+  end
+end

--- a/app/controllers/concerns/response_range_concern.rb
+++ b/app/controllers/concerns/response_range_concern.rb
@@ -5,9 +5,9 @@
 # Supports both page-specific duration filters and global performance threshold filters.
 module ResponseRangeConcern
   extend ActiveSupport::Concern
+  include RansackParamsConcern
 
   def setup_duration_range(type = :route)
-    ransack_params = params[:q] || {}
     thresholds = RailsPulse.configuration.public_send("#{type}_thresholds")
 
     # Check all duration-related parameters

--- a/app/controllers/concerns/time_range_concern.rb
+++ b/app/controllers/concerns/time_range_concern.rb
@@ -11,6 +11,7 @@
 # Normalizes times to beginning/end of hour or day based on range duration.
 module TimeRangeConcern
   extend ActiveSupport::Concern
+  include RansackParamsConcern
 
   included do
     # Define the constant in the including class - ordered by most common usage
@@ -40,8 +41,6 @@ module TimeRangeConcern
     end_time = Time.zone.now
     selected_time_range = default_key
 
-    ransack_params = params[:q] || {}
-
     # Priority 1: Page-specific preset from dropdown (check this first!)
     if ransack_params[:period_start_range].present? && ransack_params[:period_start_range].to_sym != :custom
       # Predefined time range from dropdown
@@ -59,22 +58,30 @@ module TimeRangeConcern
     elsif ransack_params[:period_start_range].present? && ransack_params[:period_start_range].to_sym == :custom && ransack_params[:custom_date_range].present? && ransack_params[:custom_date_range].include?(" to ")
       # Custom datetime range from custom range picker
       dates = ransack_params[:custom_date_range].split(" to ")
-      start_time = parse_time_param(dates[0].strip)
-      end_time = parse_time_param(dates[1].strip)
-      selected_time_range = :custom
+      custom_start = parse_time_param(dates[0].strip)
+      custom_end = parse_time_param(dates[1].strip)
+      if custom_start && custom_end
+        start_time = custom_start
+        end_time = custom_end
+        selected_time_range = :custom
+      end
     # Priority 3: Page-specific filters (chart zoom)
     elsif ransack_params[:occurred_at_gteq].present? && ransack_params[:occurred_at_lt].present?
       # Custom time range from chart zoom
-      start_time = parse_time_param(ransack_params[:occurred_at_gteq])
-      end_time = parse_time_param(ransack_params[:occurred_at_lt])
-      selected_time_range = :custom
+      zoom_start = parse_time_param(ransack_params[:occurred_at_gteq])
+      zoom_end = parse_time_param(ransack_params[:occurred_at_lt])
+      if zoom_start && zoom_end
+        start_time = zoom_start
+        end_time = zoom_end
+        selected_time_range = :custom
+      end
     # Priority 4: Time range selector (from session)
     elsif session[:time_range_preference].present?
       preference = session[:time_range_preference]
       if preference.is_a?(Hash) && preference["type"] == "custom"
         # Custom range from time range selector
-        start_time = parse_time_param(preference["start_time"])
-        end_time = parse_time_param(preference["end_time"])
+        start_time = parse_time_param(preference["start_time"]) || start_time
+        end_time = parse_time_param(preference["end_time"]) || end_time
         selected_time_range = :custom
       else
         # Preset from time range selector
@@ -90,8 +97,8 @@ module TimeRangeConcern
       end
     # Priority 5: Global filters (from session)
     elsif session_global_filters["start_time"].present? || session_global_filters["end_time"].present?
-      start_time = parse_time_param(session_global_filters["start_time"]) if session_global_filters["start_time"].present?
-      end_time = parse_time_param(session_global_filters["end_time"]) if session_global_filters["end_time"].present?
+      start_time = parse_time_param(session_global_filters["start_time"]) || start_time
+      end_time = parse_time_param(session_global_filters["end_time"]) || end_time
       selected_time_range = :custom
     end
     # Priority 6: Default time range (already set above)
@@ -112,17 +119,24 @@ module TimeRangeConcern
 
   private
 
+  # Returns nil for anything that does not parse, so a hand-edited or stale
+  # value falls back to the default range instead of raising.
   def parse_time_param(param)
     case param
     when Time, DateTime
       param.in_time_zone
     when String
+      return nil if param.blank?
+
       # Parse as server local time (not UTC, not Time.zone)
       # This ensures flatpickr datetime strings are interpreted in server's timezone
       Time.parse(param).localtime
+    when Numeric
+      Time.zone.at(param)
     else
-      # Assume it's an integer timestamp
-      Time.zone.at(param.to_i)
+      nil
     end
+  rescue ArgumentError, TypeError, RangeError
+    nil
   end
 end

--- a/app/controllers/rails_pulse/application_controller.rb
+++ b/app/controllers/rails_pulse/application_controller.rb
@@ -2,6 +2,7 @@ module RailsPulse
   class ApplicationController < ActionController::Base
     include PaginationConcern
     include SessionFiltersConcern
+    include RansackParamsConcern
 
     # Declared here rather than inherited. ActionController::Base only gets
     # protect_from_forgery from the host's `default_protect_from_forgery`,
@@ -17,6 +18,14 @@ module RailsPulse
     before_action :set_onboarding_state
     before_action :load_deployment_markers
 
+    # Values accepted into the cookie session. Everything else is dropped:
+    # the session has a 4 KB ceiling and a stored value is re-parsed on every
+    # later request, so an unbounded or unparseable string would 500 the
+    # dashboard until the cookie is cleared.
+    TIME_RANGE_PRESETS = %w[last_24_hours last_7_days last_14_days last_30_days].freeze
+    PERFORMANCE_THRESHOLDS = %w[slow very_slow critical].freeze
+    MAX_TIME_PARAM_LENGTH = 64
+
     def set_global_filters
       if params[:clear] == "true"
         session.delete(:global_filters)
@@ -25,21 +34,24 @@ module RailsPulse
         filters = session[:global_filters] || {}
 
         # Update time filters if provided
-        if params[:start_time].present? && params[:end_time].present?
-          filters["start_time"] = params[:start_time]
-          filters["end_time"] = params[:end_time]
+        start_time = valid_time_param(params[:start_time])
+        end_time = valid_time_param(params[:end_time])
+        if start_time && end_time
+          filters["start_time"] = start_time
+          filters["end_time"] = end_time
         end
 
-        # Update performance threshold if provided (or remove if empty)
-        if params[:performance_threshold].present?
-          filters["performance_threshold"] = params[:performance_threshold]
+        # Update performance threshold if provided (or remove if empty/unknown)
+        threshold = params[:performance_threshold].to_s
+        if PERFORMANCE_THRESHOLDS.include?(threshold)
+          filters["performance_threshold"] = threshold
         else
           filters.delete("performance_threshold")
         end
 
         # Update tag visibility - convert enabled tags to disabled tags
         all_tags = RailsPulse.configuration.tags
-        enabled_tags = params[:enabled_tags] || []
+        enabled_tags = Array(params[:enabled_tags]).map(&:to_s)
 
         # Handle "non_tagged" separately
         session[:show_non_tagged] = enabled_tags.include?("non_tagged")
@@ -64,15 +76,19 @@ module RailsPulse
     end
 
     def set_time_range
-      if params[:preset].present?
+      preset = params[:preset].to_s
+      start_time = valid_time_param(params[:start_time])
+      end_time = valid_time_param(params[:end_time])
+
+      if preset.present?
         # Store preset selection
-        session[:time_range_preference] = params[:preset]
-      elsif params[:start_time].present? && params[:end_time].present?
+        session[:time_range_preference] = preset if TIME_RANGE_PRESETS.include?(preset)
+      elsif start_time && end_time
         # Store custom range
         session[:time_range_preference] = {
           type: "custom",
-          start_time: params[:start_time],
-          end_time: params[:end_time]
+          start_time: start_time,
+          end_time: end_time
         }
       end
 
@@ -81,6 +97,19 @@ module RailsPulse
     end
 
     private
+
+    # The original string if it is short enough to live in the session and
+    # Time.parse accepts it (TimeRangeConcern parses it back the same way);
+    # nil otherwise.
+    def valid_time_param(value)
+      value = value.to_s.strip
+      return nil if value.blank? || value.length > MAX_TIME_PARAM_LENGTH
+
+      Time.parse(value)
+      value
+    rescue ArgumentError, TypeError
+      nil
+    end
 
     def partial_request?
       request.headers["X-Partial-Request"] == "true"

--- a/app/controllers/rails_pulse/deployments_controller.rb
+++ b/app/controllers/rails_pulse/deployments_controller.rb
@@ -9,7 +9,7 @@ module RailsPulse
     before_action :authenticate_deployment_request!, only: %i[create finish]
 
     def index
-      @ransack_query = Deployment.ransack(params[:q] || {})
+      @ransack_query = Deployment.ransack(ransack_params)
       @ransack_query.sorts = "started_at desc" if @ransack_query.sorts.empty?
       @pagination, @table_data = paginate(@ransack_query.result, limit: session_pagination_limit)
     end

--- a/app/controllers/rails_pulse/exceptions_controller.rb
+++ b/app/controllers/rails_pulse/exceptions_controller.rb
@@ -7,7 +7,7 @@ module RailsPulse
     before_action :set_exception_group, only: %i[show update]
 
     def index
-      ransack_params = (params[:q] || {}).dup
+      ransack_params = self.ransack_params.dup
       apply_default_status_filter!(ransack_params)
 
       @ransack_query = ExceptionGroup.ransack(ransack_params)

--- a/app/controllers/rails_pulse/job_runs_controller.rb
+++ b/app/controllers/rails_pulse/job_runs_controller.rb
@@ -6,7 +6,7 @@ module RailsPulse
     before_action :set_run, only: :show
 
     def index
-      @ransack_query = @job.runs.ransack(params[:q])
+      @ransack_query = @job.runs.ransack(ransack_params)
       @pagination, @runs = paginate(@ransack_query.result.order(occurred_at: :desc), limit: session_pagination_limit)
       @table_data = @runs
     end

--- a/app/controllers/rails_pulse/requests_controller.rb
+++ b/app/controllers/rails_pulse/requests_controller.rb
@@ -109,7 +109,7 @@ module RailsPulse
 
       # If filtering or sorting by route_path, we need to join the routes table
       needs_join = @ransack_query.sorts.any? { |sort| sort.name == "route_path" } ||
-                   params.dig(:q, :route_path_cont).present?
+                   ransack_params[:route_path_cont].present?
 
       if needs_join
         base_query = base_query.joins(:route)

--- a/app/helpers/rails_pulse/backtrace_helper.rb
+++ b/app/helpers/rails_pulse/backtrace_helper.rb
@@ -34,12 +34,20 @@ module RailsPulse
       File.basename(frame_display_path(frame))
     end
 
+    # Directories (relative to Rails.root) whose source may be shown, and the
+    # file types within them. Everything else under Rails.root — initializers
+    # with inline keys, credentials, database.yml, .env, tmp/ — stays
+    # unreadable even when a backtrace frame points at it.
+    SOURCE_ALLOWED_DIRECTORIES = %w[app/ lib/].freeze
+    SOURCE_ALLOWED_FILES = %w[config/routes.rb].freeze
+    SOURCE_ALLOWED_EXTENSIONS = %w[.rb .erb .rake .haml .slim .jbuilder].freeze
+
     def frame_source_lines(frame, radius: 3)
       file = frame["file"].to_s
       line = frame["line"].to_i
       return nil if file.blank? || line < 1
       return nil unless File.exist?(file) && File.file?(file)
-      return nil unless path_within_rails_root?(file)
+      return nil unless source_readable?(file)
 
       first_line = [ line - radius, 1 ].max
       last_line  = line + radius
@@ -56,12 +64,20 @@ module RailsPulse
 
     private
 
-    # Only read source for files under Rails.root to avoid leaking arbitrary
-    # filesystem contents via crafted backtrace paths.
-    def path_within_rails_root?(file)
+    # Only read source for code files under Rails.root's app/ and lib/ (plus
+    # config/routes.rb). Resolved through realpath so symlinks cannot point
+    # outside, and matched on the relative path so a directory merely named
+    # "app" elsewhere on disk does not qualify.
+    def source_readable?(file)
       real = File.realpath(file)
-      root = Rails.root.realpath.to_s
-      real == root || real.start_with?("#{root}#{File::SEPARATOR}")
+      root = "#{Rails.root.realpath}#{File::SEPARATOR}"
+      return false unless real.start_with?(root)
+
+      relative = real.delete_prefix(root)
+      return false unless SOURCE_ALLOWED_EXTENSIONS.include?(File.extname(relative))
+
+      SOURCE_ALLOWED_FILES.include?(relative) ||
+        SOURCE_ALLOWED_DIRECTORIES.any? { |dir| relative.start_with?(dir) }
     rescue Errno::ENOENT
       false
     end

--- a/app/models/concerns/rails_pulse/taggable.rb
+++ b/app/models/concerns/rails_pulse/taggable.rb
@@ -5,20 +5,25 @@ module RailsPulse
     # Tag validation constants
     TAG_NAME_REGEX = /\A[a-z0-9_-]+\z/i
     MAX_TAG_LENGTH = 50
+    # Escape character for LIKE patterns over the serialized tags column.
+    # Never appears in a valid tag name, and needs no quoting on any adapter.
+    LIKE_ESCAPE = "!".freeze
 
     included do
       # Callbacks
       before_save :ensure_tags_is_array
 
-      # Scopes with table name qualification to avoid ambiguity
-      # Note: LIKE patterns are sanitized to prevent SQL injection via wildcards
+      # Scopes with table name qualification to avoid ambiguity.
+      # LIKE patterns are sanitized so `_`/`%` in a tag are matched literally.
+      # The ESCAPE clause is explicit because SQLite has no default escape
+      # character — without it `my\_tag` matches a literal backslash there
+      # and the filter silently matches nothing. `!` is used rather than `\`
+      # because MySQL and PostgreSQL disagree on how to quote a backslash.
       scope :with_tag, ->(tag) {
-        sanitized_tag = sanitize_sql_like(tag.to_s, "\\")
-        where("#{table_name}.tags LIKE ?", "%\"#{sanitized_tag}\"%")
+        where("#{table_name}.tags LIKE ? ESCAPE '!'", "%\"#{sanitize_sql_like(tag.to_s, LIKE_ESCAPE)}\"%")
       }
       scope :without_tag, ->(tag) {
-        sanitized_tag = sanitize_sql_like(tag.to_s, "\\")
-        where.not("#{table_name}.tags LIKE ?", "%\"#{sanitized_tag}\"%")
+        where.not("#{table_name}.tags LIKE ? ESCAPE '!'", "%\"#{sanitize_sql_like(tag.to_s, LIKE_ESCAPE)}\"%")
       }
       scope :with_tags, -> { where("#{table_name}.tags IS NOT NULL AND #{table_name}.tags != '[]'") }
     end

--- a/app/models/rails_pulse/deployment.rb
+++ b/app/models/rails_pulse/deployment.rb
@@ -2,8 +2,18 @@ module RailsPulse
   class Deployment < RailsPulse::ApplicationRecord
     self.table_name = "rails_pulse_deployments"
 
-    validates :revision,   presence: true
+    # The create endpoint is reachable with a CI token, so every field a
+    # caller controls is bounded: a leaked token must not be able to fill the
+    # table or push a marker into the future (which would stamp every later
+    # exception with a revision that has not shipped).
+    MAX_REVISION_LENGTH = 255
+    MAX_METADATA_BYTES  = 4.kilobytes
+    MAX_CLOCK_SKEW      = 1.hour
+
+    validates :revision,   presence: true, length: { maximum: MAX_REVISION_LENGTH }
     validates :started_at, presence: true
+    validate  :started_at_is_not_in_the_future
+    validate  :metadata_is_within_size_limit
 
     scope :for_range, ->(start_time, end_time) { where(started_at: start_time..end_time) }
     scope :recent,    -> { order(started_at: :desc) }
@@ -45,6 +55,22 @@ module RailsPulse
 
     def to_chart_marker
       { timestamp: started_at.to_i * 1000, revision: revision, started_at: started_at.iso8601 }
+    end
+
+    private
+
+    def started_at_is_not_in_the_future
+      return if started_at.blank?
+      return if started_at <= MAX_CLOCK_SKEW.from_now
+
+      errors.add(:started_at, "can't be more than #{MAX_CLOCK_SKEW.inspect} in the future")
+    end
+
+    def metadata_is_within_size_limit
+      return if metadata.blank?
+      return if metadata.to_s.bytesize <= MAX_METADATA_BYTES
+
+      errors.add(:metadata, "is too large (maximum is #{MAX_METADATA_BYTES.to_i / 1024} KB)")
     end
   end
 end

--- a/app/models/rails_pulse/operation.rb
+++ b/app/models/rails_pulse/operation.rb
@@ -112,20 +112,26 @@ module RailsPulse
       Arel.sql("COUNT(rails_pulse_operations.id)")
     end
 
-    ransacker :occurred_at, formatter: ->(val) {
-      # Handle different time formats for database compatibility
+    # Handle different time formats for database compatibility. An
+    # unparseable value becomes nil, which Ransack treats as "no filter",
+    # rather than a 500 from a hand-edited query string.
+    OCCURRED_AT_FORMATTER = lambda do |val|
       case val
       when Time, DateTime, ActiveSupport::TimeWithZone
         val.utc.iso8601
       when String
-        Time.zone.parse(val).utc.iso8601
+        Time.zone.parse(val)&.utc&.iso8601
       when Integer
         Time.at(val).utc.iso8601
       else
         # Fallback: try to parse as integer timestamp
         Time.at(val.to_i).utc.iso8601
       end
-    } do |parent|
+    rescue ArgumentError, TypeError
+      nil
+    end
+
+    ransacker :occurred_at, formatter: OCCURRED_AT_FORMATTER do |parent|
       parent.table[:occurred_at]
     end
 

--- a/app/models/rails_pulse/tables/base.rb
+++ b/app/models/rails_pulse/tables/base.rb
@@ -41,9 +41,11 @@ module RailsPulse
       def apply_tag_filters(query)
         actual_disabled_tags = @disabled_tags.reject { |tag| tag == "non_tagged" }
 
+        # Explicit ESCAPE: SQLite has no default escape character, so without
+        # it an underscore in a tag is never matched literally there.
         actual_disabled_tags.each do |tag|
-          sanitized_tag = ActiveRecord::Base.sanitize_sql_like(tag.to_s, "\\")
-          query = query.where.not("#{model_table}.tags LIKE ?", "%#{sanitized_tag}%")
+          sanitized_tag = ActiveRecord::Base.sanitize_sql_like(tag.to_s, RailsPulse::Taggable::LIKE_ESCAPE)
+          query = query.where.not("#{model_table}.tags LIKE ? ESCAPE '!'", "%#{sanitized_tag}%")
         end
 
         unless @show_non_tagged

--- a/app/services/rails_pulse/tag_filter_service.rb
+++ b/app/services/rails_pulse/tag_filter_service.rb
@@ -8,10 +8,12 @@ module RailsPulse
     def self.filter_ids(model_class, disabled_tags, show_non_tagged)
       relation = model_class.all
 
-      # Exclude items with disabled tags
+      # Exclude items with disabled tags. Explicit ESCAPE: SQLite has no
+      # default escape character, so without it an underscore in a tag is
+      # never matched literally there and the exclusion matches nothing.
       disabled_tags.each do |tag|
-        sanitized_tag = ActiveRecord::Base.sanitize_sql_like(tag.to_s, "\\")
-        relation = relation.where.not("tags LIKE ?", "%#{sanitized_tag}%")
+        sanitized_tag = ActiveRecord::Base.sanitize_sql_like(tag.to_s, RailsPulse::Taggable::LIKE_ESCAPE)
+        relation = relation.where.not("tags LIKE ? ESCAPE '!'", "%#{sanitized_tag}%")
       end
 
       # Exclude non-tagged items if show_non_tagged is false

--- a/docs/deployment-modes.md
+++ b/docs/deployment-modes.md
@@ -67,56 +67,40 @@ end
 
 **Standalone Server:**
 
-The standalone server can run from either:
-- **Your Rails app directory** (recommended): Has access to your `config/database.yml`
-- **Rails Pulse gem directory**: For development/testing
+The dashboard is a mounted engine: it needs your app's models, routes and
+`config/initializers/rails_pulse.rb` (authentication, database connection), so
+the server must start from your Rails application's root directory. It loads
+`config/environment.rb` from there and refuses to boot without it.
 
 ```bash
-# From your Rails app directory
-bundle exec rackup lib/rails_pulse_server.ru -p 3001
-
-# Or from the Rails Pulse gem directory (for development)
-cd vendor/bundle/ruby/*/gems/rails_pulse-*
-bundle exec rackup lib/rails_pulse_server.ru -p 3001
+cd /path/to/your/app
+RAILS_ENV=production bundle exec rackup $(bundle show rails_pulse)/lib/rails_pulse_server.ru -p 3001
 ```
 
-**Database Connection:**
+`RAILS_ENV` matters twice: it selects the database (from `config/database.yml`
+or `DATABASE_URL`, exactly as the main app does), and it decides whether
+dashboard authentication is on — the default is enabled outside `development`
+and `test`, so an unset `RAILS_ENV` boots an unauthenticated dashboard against
+the development database.
 
-The standalone server needs to connect to the same database as your main app. It supports two configuration methods (in priority order):
+Two environment variables are required or strongly recommended:
 
-**Option 1: DATABASE_URL environment variable (recommended for production)**
-   ```bash
-   export DATABASE_URL="postgresql://user:pass@host/db"
-   bundle exec rackup lib/rails_pulse_server.ru -p 3001
-   ```
+- `SECRET_KEY_BASE` — the server refuses to start without it; it signs the
+  dashboard's session cookie.
+- `RAILS_ENV=production` — see above.
 
-**Option 2: config/database.yml (recommended for development)**
+The session cookie is marked `Secure` in production, so it is only sent over
+HTTPS. Terminate TLS at your reverse proxy (see the nginx example below). For a
+deliberately non-TLS deployment on a private network, set
+`RAILS_PULSE_INSECURE_SESSION=1`.
 
-   When running from your Rails app directory, the server automatically reads `config/database.yml`:
-   - First looks for a `rails_pulse` connection in your current environment
-   - Falls back to the primary connection if `rails_pulse` is not defined
-   - Respects `RAILS_ENV` (defaults to `production`)
-
-   Example `config/database.yml`:
-   ```yaml
-   production:
-     primary:
-       adapter: postgresql
-       database: myapp_production
-       # ... other settings
-
-     # Optional: Dedicated connection for Rails Pulse
-     rails_pulse:
-       adapter: postgresql
-       database: myapp_production  # Same database, but isolated connection pool
-       # ... other settings
-   ```
-
-**Important:** The server will fail to start if neither DATABASE_URL nor config/database.yml is available.
+For development against the gem's own dummy app, run the same command from the
+gem root instead.
 
 **Deployment with Kamal:**
 
-Deploy the dashboard as an accessory
+Deploy the dashboard as an accessory using the same image as your app, so
+`config/environment.rb` and your initializer are present:
 
 ```yaml
 # config/deploy.yml
@@ -124,40 +108,19 @@ accessories:
   rails_pulse:
     image: your-app-image  # Same image as your main app
     host: your-server
-    cmd: bundle exec rackup lib/rails_pulse_server.ru -p 3001
+    cmd: sh -c 'bundle exec rackup $(bundle show rails_pulse)/lib/rails_pulse_server.ru -p 3001'
     env:
       clear:
-        DATABASE_URL: "postgresql://user:pass@host/db"
         RAILS_ENV: production
-        # Optional: Secret for session cookies (defaults to random value)
-        SECRET_KEY_BASE: <%= ENV.fetch("SECRET_KEY_BASE") %>
+      secret:
+        - SECRET_KEY_BASE
+        - DATABASE_URL          # or rely on config/database.yml in the image
     port: "3001:3001"  # Map container port to host port
     healthcheck:
       path: /health
       port: 3001
       interval: 10s
       timeout: 5s
-```
-
-**Alternative Kamal config using database.yml:**
-
-If your app image includes `config/database.yml`, you can omit DATABASE_URL:
-
-```yaml
-accessories:
-  rails_pulse:
-    image: your-app-image
-    host: your-server
-    cmd: bundle exec rackup lib/rails_pulse_server.ru -p 3001
-    env:
-      clear:
-        RAILS_ENV: production
-        SECRET_KEY_BASE: <%= ENV.fetch("SECRET_KEY_BASE") %>
-    port: "3001:3001"
-    healthcheck:
-      path: /health
-      port: 3001
-      interval: 10s
 ```
 
 **Nginx Configuration:**

--- a/lib/generators/rails_pulse/templates/rails_pulse.rb
+++ b/lib/generators/rails_pulse/templates/rails_pulse.rb
@@ -323,6 +323,10 @@ RailsPulse.configure do |config|
   #   config.deployment_api_token = Rails.application.credentials.dig(:rails_pulse, :deployment_api_token)
   #   config.deployment_api_token = ENV["RAILS_PULSE_DEPLOYMENT_TOKEN"]
   #
+  # Limits: revision ≤ 255 characters, metadata ≤ 4 KB serialized, started_at at most
+  # one hour in the future. Rows beyond max_table_records[:rails_pulse_deployments]
+  # are pruned oldest-first by the cleanup task.
+  #
   # Record a deployment from your CI/CD pipeline:
   #   curl -X POST https://yourapp.com/rails_pulse/deployments \
   #     -H "X-Rails-Pulse-Token: $RAILS_PULSE_DEPLOYMENT_TOKEN" \
@@ -363,7 +367,8 @@ RailsPulse.configure do |config|
     rails_pulse_job_runs: 50_000,                 # Individual job executions (high volume)
     rails_pulse_jobs: 1_000,                      # Unique job classes (low volume)
     rails_pulse_exception_occurrences: 50_000,    # Individual exception raises (high volume)
-    rails_pulse_exception_groups: 10_000          # Distinct exception sites (moderate volume)
+    rails_pulse_exception_groups: 10_000,         # Distinct exception sites (moderate volume)
+    rails_pulse_deployments: 1_000                # Deploy markers (low volume; oldest pruned first)
   }
 
   # ====================================================================================================

--- a/lib/rails_pulse/cleanup_service.rb
+++ b/lib/rails_pulse/cleanup_service.rb
@@ -78,6 +78,21 @@ module RailsPulse
         @stats[:count_based][:exception_groups]      = cleanup_exception_groups_by_count
         @stats[:count_based][:orphaned_exception_groups] = cleanup_orphaned_exception_groups
       end
+      if deployments_table_exists?
+        @stats[:count_based][:deployments] = cleanup_deployments_by_count
+      end
+    end
+
+    # Deployments are markers, not measurements, so they are never pruned by
+    # age — a marker from before the retention window still explains a
+    # summary row. They are capped by count so the token-authenticated
+    # create endpoint cannot grow the table without bound.
+    def cleanup_deployments_by_count
+      cleanup_by_count(RailsPulse::Deployment, :rails_pulse_deployments, order_column: :started_at)
+    end
+
+    def deployments_table_exists?
+      RailsPulse::ApplicationRecord.connection.table_exists?(:rails_pulse_deployments)
     end
 
     # Shared helper: delete oldest records beyond a configured max count

--- a/lib/rails_pulse/configuration.rb
+++ b/lib/rails_pulse/configuration.rb
@@ -94,7 +94,8 @@ module RailsPulse
         rails_pulse_routes: 1_000,
         rails_pulse_jobs: 1_000,
         rails_pulse_exception_occurrences: 50_000,
-        rails_pulse_exception_groups: 10_000
+        rails_pulse_exception_groups: 10_000,
+        rails_pulse_deployments: 1_000
       }
       @connects_to = nil
       @authentication_enabled = !(Rails.env.development? || Rails.env.test?)

--- a/lib/rails_pulse_server.ru
+++ b/lib/rails_pulse_server.ru
@@ -1,58 +1,22 @@
-# Load Rails environment - try multiple locations
+# Load the host Rails environment. The dashboard is a mounted engine and needs
+# the host's models, routes and initializer (authentication, database), so run
+# this from the Rails application's root — or from the gem root, which loads
+# the dummy app for development.
 if File.exist?("test/dummy/config/environment.rb")
-  # Running from Rails Pulse gem root (for development/testing)
   require_relative "../test/dummy/config/environment"
 elsif File.exist?("config/environment.rb")
-  # Running from a Rails app that has Rails Pulse installed
   require File.expand_path("config/environment", Dir.pwd)
 else
-  # Standalone mode - load minimal dependencies
-  puts "=" * 80
-  puts "RailsPulse Dashboard (Standalone Mode)"
-  puts "=" * 80
+  abort <<~MESSAGE
+    RailsPulse standalone dashboard: config/environment.rb not found in #{Dir.pwd}.
 
-  require "bundler/setup"
-  require "active_support/all"
-  require "active_record"
+    Run from your Rails application's root directory:
 
-  $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
-  require "rails_pulse"
+      cd /path/to/your/app
+      RAILS_ENV=production bundle exec rackup $(bundle show rails_pulse)/lib/rails_pulse_server.ru -p 3001
 
-  # Load database configuration from environment
-  db_config = if ENV["DATABASE_URL"]
-    { url: ENV["DATABASE_URL"] }
-  elsif File.exist?("config/database.yml")
-    require "yaml"
-    db_yml = YAML.load_file("config/database.yml", aliases: true)
-    rails_env = ENV.fetch("RAILS_ENV", "production")
-
-    rails_pulse_config = db_yml.dig(rails_env, "rails_pulse")
-    if rails_pulse_config
-      rails_pulse_config
-    else
-      puts "WARNING: No 'rails_pulse' database found in config/database.yml, using primary connection"
-      db_yml[rails_env]
-    end
-  else
-    raise "Database configuration not found. Set DATABASE_URL or provide config/database.yml"
-  end
-
-  puts "Connecting to database: #{db_config[:database] || db_config[:url]&.split('@')&.last}"
-
-  # Configure RailsPulse for dashboard-only mode
-  RailsPulse.configure do |config|
-    # CRITICAL: Disable tracking in dashboard process
-    config.enabled = false
-
-    # Configure database connection
-    config.connects_to = { database: db_config }
-  end
-
-  # Establish database connection
-  RailsPulse::ApplicationRecord.establish_connection(db_config)
-
-  puts "Dashboard ready on port #{ENV.fetch('PORT', 3001)}"
-  puts "=" * 80
+    RAILS_ENV selects the database and enables dashboard authentication.
+  MESSAGE
 end
 
 # Disable output buffering so logs appear immediately
@@ -99,10 +63,15 @@ secret_key = ENV.fetch("SECRET_KEY_BASE") do
   raise "SECRET_KEY_BASE environment variable must be set for standalone dashboard"
 end
 
+# `secure` keeps the session cookie off plain HTTP in production. Set
+# RAILS_PULSE_INSECURE_SESSION=1 only for a deliberately non-TLS deployment
+# (a private network with no reverse proxy in front).
 use Rack::Session::Cookie,
   key: "rails_pulse_session",
   secret: secret_key,
   same_site: :lax,
+  httponly: true,
+  secure: Rails.env.production? && ENV["RAILS_PULSE_INSECURE_SESSION"].blank?,
   max_age: 86400  # 1 day
 
 run DashboardApp.new

--- a/test/controllers/concerns/time_range_concern_test.rb
+++ b/test/controllers/concerns/time_range_concern_test.rb
@@ -217,6 +217,45 @@ class TimeRangeConcernTest < ActionController::TestCase
     assert_equal "last_24_hours", selected_range
   end
 
+  test "setup_time_range falls back to the default when custom dates do not parse" do
+    @controller.params = ActionController::Parameters.new(q: {
+      period_start_range: "custom",
+      custom_date_range: "not-a-date to also-not-a-date"
+    })
+
+    _start_time, _end_time, selected_range, _time_diff = @controller.send(:setup_time_range)
+
+    assert_equal "last_24_hours", selected_range
+  end
+
+  test "setup_time_range tolerates q that is not a hash" do
+    @controller.params = ActionController::Parameters.new(q: "garbage")
+
+    _start_time, _end_time, selected_range, _time_diff = @controller.send(:setup_time_range)
+
+    assert_equal "last_24_hours", selected_range
+  end
+
+  test "setup_time_range ignores unparseable zoom bounds" do
+    @controller.params = ActionController::Parameters.new(q: {
+      occurred_at_gteq: "yesterday-ish",
+      occurred_at_lt: "later"
+    })
+
+    _start_time, _end_time, selected_range, _time_diff = @controller.send(:setup_time_range)
+
+    assert_equal "last_24_hours", selected_range
+  end
+
+  test "setup_time_range ignores unparseable session filters" do
+    @controller.session[:global_filters] = { "start_time" => "x" * 100, "end_time" => "nope" }
+
+    start_time, end_time, selected_range, _time_diff = @controller.send(:setup_time_range)
+
+    assert_equal "custom", selected_range
+    assert_operator start_time, :<, end_time
+  end
+
   # Priority 3: Chart Zoom Tests
 
   test "setup_time_range uses occurred_at_gteq and occurred_at_lt" do

--- a/test/controllers/rails_pulse/application_controller_test.rb
+++ b/test/controllers/rails_pulse/application_controller_test.rb
@@ -769,6 +769,55 @@ class RailsPulse::ApplicationControllerTest < ActionDispatch::IntegrationTest
 
   # Edge Cases
 
+  # Session Input Validation
+
+  test "set_global_filters ignores unparseable time params" do
+    patch rails_pulse.settings_global_filters_path, params: {
+      start_time: "not a time",
+      end_time: "2024-01-31 23:59"
+    }
+
+    assert_response :redirect
+    refute_includes session[:global_filters].keys, "start_time"
+  end
+
+  test "set_global_filters ignores oversized time params" do
+    # Time.parse is lenient about trailing words, so this parses — but it
+    # must not be allowed into the 4 KB cookie session.
+    patch rails_pulse.settings_global_filters_path, params: {
+      start_time: "2024-01-01 00:00 " + ("padding " * 8),
+      end_time: "2024-01-31 23:59"
+    }
+
+    refute_includes session[:global_filters].keys, "start_time"
+  end
+
+  test "set_global_filters drops an unknown performance threshold" do
+    patch rails_pulse.settings_global_filters_path, params: { performance_threshold: "<script>" }
+
+    refute_includes session[:global_filters].keys, "performance_threshold"
+  end
+
+  test "set_global_filters tolerates enabled_tags sent as a string" do
+    patch rails_pulse.settings_global_filters_path, params: { enabled_tags: "critical" }
+
+    assert_response :redirect
+    assert_equal RailsPulse.configuration.tags - [ "critical" ], session[:global_filters]["disabled_tags"]
+  end
+
+  test "set_time_range ignores an unknown preset" do
+    patch rails_pulse.settings_time_range_path, params: { preset: "x" * 2_000 }
+
+    assert_response :redirect
+    assert_nil session[:time_range_preference]
+  end
+
+  test "set_time_range ignores an unparseable custom range" do
+    patch rails_pulse.settings_time_range_path, params: { start_time: "garbage", end_time: "2024-01-31" }
+
+    assert_nil session[:time_range_preference]
+  end
+
   test "set_global_filters handles empty time params" do
     patch rails_pulse.settings_global_filters_path, params: {
       start_time: "",

--- a/test/controllers/rails_pulse/application_controller_test.rb
+++ b/test/controllers/rails_pulse/application_controller_test.rb
@@ -799,10 +799,12 @@ class RailsPulse::ApplicationControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "set_global_filters tolerates enabled_tags sent as a string" do
+    RailsPulse.configuration.stubs(:tags).returns([ "api", "critical" ])
+
     patch rails_pulse.settings_global_filters_path, params: { enabled_tags: "critical" }
 
     assert_response :redirect
-    assert_equal RailsPulse.configuration.tags - [ "critical" ], session[:global_filters]["disabled_tags"]
+    assert_equal [ "api" ], session[:global_filters]["disabled_tags"]
   end
 
   test "set_time_range ignores an unknown preset" do

--- a/test/controllers/rails_pulse/deployments_controller_test.rb
+++ b/test/controllers/rails_pulse/deployments_controller_test.rb
@@ -218,6 +218,43 @@ class RailsPulse::DeploymentsControllerTest < ActionDispatch::IntegrationTest
     assert_not_empty json["errors"]
   end
 
+  test "create returns 422 for an oversized revision" do
+    assert_no_difference -> { RailsPulse::Deployment.count } do
+      post rails_pulse.deployments_path,
+           params: { deployment: { revision: "x" * 300 } },
+           as: :json
+    end
+
+    assert_response :unprocessable_content
+  end
+
+  test "create returns 422 for oversized metadata" do
+    assert_no_difference -> { RailsPulse::Deployment.count } do
+      post rails_pulse.deployments_path,
+           params: { deployment: { revision: "sha", metadata: { notes: "x" * 5_000 } } },
+           as: :json
+    end
+
+    assert_response :unprocessable_content
+    assert_match(/too large/, response.body)
+  end
+
+  test "create returns 422 for a started_at in the future" do
+    assert_no_difference -> { RailsPulse::Deployment.count } do
+      post rails_pulse.deployments_path,
+           params: { deployment: { revision: "sha", started_at: 1.day.from_now.iso8601 } },
+           as: :json
+    end
+
+    assert_response :unprocessable_content
+  end
+
+  test "index tolerates a non-hash q param" do
+    get rails_pulse.deployments_path, params: { q: "garbage" }
+
+    assert_response :success
+  end
+
   test "create returns 400 when deployment params are missing" do
     assert_no_difference -> { RailsPulse::Deployment.count } do
       post rails_pulse.deployments_path,

--- a/test/controllers/rails_pulse/exceptions_controller_test.rb
+++ b/test/controllers/rails_pulse/exceptions_controller_test.rb
@@ -27,6 +27,12 @@ class RailsPulse::ExceptionsControllerTest < ActionDispatch::IntegrationTest
     assert_respond_to controller, :update
   end
 
+  test "index tolerates a non-hash q param" do
+    get rails_pulse.exceptions_path, params: { q: "garbage" }
+
+    assert_response :success
+  end
+
   # Index Action Tests
 
   test "index responds successfully" do

--- a/test/controllers/rails_pulse/requests_controller_test.rb
+++ b/test/controllers/rails_pulse/requests_controller_test.rb
@@ -13,6 +13,18 @@ class RailsPulse::RequestsControllerTest < ActionDispatch::IntegrationTest
 
   # Controller Structure Tests
 
+  test "index tolerates a non-hash q param" do
+    get rails_pulse.requests_path, params: { q: "garbage" }
+
+    assert_response :success
+  end
+
+  test "index tolerates an unparseable occurred_at filter" do
+    get rails_pulse.requests_path, params: { q: { occurred_at_gteq: "not-a-time" } }
+
+    assert_response :success
+  end
+
   test "controller includes required concerns" do
     assert_includes RailsPulse::RequestsController.included_modules, ChartTableConcern
     assert_includes RailsPulse::RequestsController.included_modules, TagFilterConcern

--- a/test/dummy/config/initializers/rails_pulse.rb
+++ b/test/dummy/config/initializers/rails_pulse.rb
@@ -282,6 +282,7 @@ RailsPulse.configure do |config|
     rails_pulse_job_runs: 50000,                 # Individual job executions (high volume)
     rails_pulse_jobs: 1000,                      # Unique job classes (low volume)
     rails_pulse_exception_occurrences: 50000,    # Individual exception raises (high volume)
-    rails_pulse_exception_groups: 10000          # Distinct exception sites (moderate volume)
+    rails_pulse_exception_groups: 10000,         # Distinct exception sites (moderate volume)
+    rails_pulse_deployments: 1000                # Deploy markers (low volume)
   }
 end

--- a/test/helpers/rails_pulse/backtrace_helper_test.rb
+++ b/test/helpers/rails_pulse/backtrace_helper_test.rb
@@ -174,6 +174,50 @@ class RailsPulse::BacktraceHelperTest < ActionView::TestCase
     end
   end
 
+  # Allow-list: only application code is ever read from disk.
+
+  test "frame_source_lines reads files under app/" do
+    with_source_file("class Foo; end", relative_dir: "app/backtrace_helper_test") do |path|
+      assert_equal({ 1 => "class Foo; end" }, frame_source_lines({ "file" => path, "line" => 1 }))
+    end
+  end
+
+  test "frame_source_lines reads config/routes.rb" do
+    result = frame_source_lines({ "file" => Rails.root.join("config/routes.rb").to_s, "line" => 1 })
+
+    assert_kind_of Hash, result
+    assert_includes result.keys, 1
+  end
+
+  test "frame_source_lines refuses initializers" do
+    with_source_file("STRIPE_KEY = 'sk_live_secret'", relative_dir: "config/initializers") do |path|
+      assert_nil frame_source_lines({ "file" => path, "line" => 1 })
+    end
+  end
+
+  test "frame_source_lines refuses files under tmp/" do
+    with_source_file("some content", relative_dir: "tmp") do |path|
+      assert_nil frame_source_lines({ "file" => path, "line" => 1 })
+    end
+  end
+
+  test "frame_source_lines refuses non-code files even under app/" do
+    with_source_file("password: hunter2", relative_dir: "app/backtrace_helper_test", extension: ".yml") do |path|
+      assert_nil frame_source_lines({ "file" => path, "line" => 1 })
+    end
+  end
+
+  test "frame_source_lines refuses a directory merely named app outside Rails.root" do
+    Dir.mktmpdir do |outside|
+      dir = File.join(outside, "app")
+      FileUtils.mkdir_p(dir)
+      path = File.join(dir, "leak.rb")
+      File.write(path, "secret")
+
+      assert_nil frame_source_lines({ "file" => path, "line" => 1 })
+    end
+  end
+
   test "frame_source_lines returns nil for missing file" do
     frame = { "file" => "/nonexistent/path/file.rb", "line" => 5 }
 
@@ -241,11 +285,13 @@ class RailsPulse::BacktraceHelperTest < ActionView::TestCase
 
   private
 
-  # Source preview is restricted to Rails.root — write fixtures under tmp/.
-  def with_source_file(contents)
-    dir = Rails.root.join("tmp")
+  # Source preview is restricted to code under Rails.root/app and /lib —
+  # write fixtures under lib/ by default; tests for the allow-list pass
+  # another relative directory or extension.
+  def with_source_file(contents, relative_dir: "lib/backtrace_helper_test", extension: ".rb")
+    dir = Rails.root.join(relative_dir)
     FileUtils.mkdir_p(dir)
-    path = dir.join("backtrace_helper_test_#{SecureRandom.hex(8)}.rb")
+    path = dir.join("fixture_#{SecureRandom.hex(8)}#{extension}")
     File.write(path, contents)
     yield path.to_s
   ensure

--- a/test/lib/rails_pulse/cleanup_service_test.rb
+++ b/test/lib/rails_pulse/cleanup_service_test.rb
@@ -132,6 +132,34 @@ module RailsPulse
       end
     end
 
+    test "count-based cleanup prunes the oldest deployments beyond max" do
+      RailsPulse::Deployment.delete_all
+      RailsPulse.configuration.max_table_records = { rails_pulse_deployments: 2 }
+      RailsPulse.configuration.instance_variable_set(:@full_retention_period, nil)
+
+      oldest = RailsPulse::Deployment.create!(revision: "old", started_at: 3.days.ago)
+      RailsPulse::Deployment.create!(revision: "mid", started_at: 2.days.ago)
+      newest = RailsPulse::Deployment.create!(revision: "new", started_at: 1.day.ago)
+
+      stats = CleanupService.perform
+
+      assert_equal 1, stats[:count_based][:deployments]
+      assert_equal 2, RailsPulse::Deployment.count
+      assert_not RailsPulse::Deployment.exists?(oldest.id)
+      assert RailsPulse::Deployment.exists?(newest.id)
+    end
+
+    test "time-based cleanup never deletes deployments" do
+      RailsPulse::Deployment.delete_all
+      RailsPulse.configuration.max_table_records = nil
+      RailsPulse.configuration.full_retention_period = 1.day
+      RailsPulse::Deployment.create!(revision: "ancient", started_at: 400.days.ago)
+
+      assert_no_difference -> { RailsPulse::Deployment.count } do
+        CleanupService.perform
+      end
+    end
+
     test "count-based cleanup keeps jobs within max limit" do
       RailsPulse.configuration.max_table_records = {
         rails_pulse_operations: 10_000,

--- a/test/lib/rails_pulse/configuration_test.rb
+++ b/test/lib/rails_pulse/configuration_test.rb
@@ -74,6 +74,7 @@ module RailsPulse
         rails_pulse_operations rails_pulse_requests rails_pulse_job_runs
         rails_pulse_queries rails_pulse_routes rails_pulse_jobs
         rails_pulse_exception_occurrences rails_pulse_exception_groups
+        rails_pulse_deployments
       ]
 
       expected_tables.each do |key|

--- a/test/lib/rails_pulse/standalone_server_test.rb
+++ b/test/lib/rails_pulse/standalone_server_test.rb
@@ -74,6 +74,41 @@ module RailsPulse
       assert_not_nil get("/").headers["Set-Cookie"]
     end
 
+    test "session cookie is HttpOnly and not Secure outside production" do
+      cookie = get("/").headers["Set-Cookie"]
+
+      assert_match(/httponly/i, cookie)
+      assert_no_match(/;\s*secure/i, cookie)
+    end
+
+    test "session cookie is Secure in production" do
+      app = with_rails_env("production") { build_server_app }
+
+      cookie = Rack::MockRequest.new(app).get("https://pulse.example.com/").headers["Set-Cookie"]
+
+      assert_match(/;\s*secure/i, cookie)
+    end
+
+    test "no session cookie is issued over plain HTTP in production" do
+      app = with_rails_env("production") { build_server_app }
+
+      # rack-session refuses to write a Secure cookie on a non-TLS request,
+      # so the session simply never reaches the browser.
+      assert_nil Rack::MockRequest.new(app).get("http://pulse.example.com/").headers["Set-Cookie"]
+    end
+
+    test "RAILS_PULSE_INSECURE_SESSION opts out of the Secure flag in production" do
+      original = ENV["RAILS_PULSE_INSECURE_SESSION"]
+      ENV["RAILS_PULSE_INSECURE_SESSION"] = "1"
+      app = with_rails_env("production") { build_server_app }
+
+      cookie = Rack::MockRequest.new(app).get("/").headers["Set-Cookie"]
+
+      assert_no_match(/;\s*secure/i, cookie)
+    ensure
+      ENV["RAILS_PULSE_INSECURE_SESSION"] = original
+    end
+
     # Server Configuration Tests
 
     test "server raises when SECRET_KEY_BASE is not set" do
@@ -86,6 +121,14 @@ module RailsPulse
 
     def build_server_app
       Rack::Builder.parse_file(SERVER_RU)
+    end
+
+    # The rackup reads Rails.env once, while the middleware stack is built.
+    def with_rails_env(name)
+      Rails.stubs(:env).returns(ActiveSupport::EnvironmentInquirer.new(name))
+      yield
+    ensure
+      Rails.unstub(:env)
     end
 
     def get(path)

--- a/test/models/concerns/rails_pulse/taggable_test.rb
+++ b/test/models/concerns/rails_pulse/taggable_test.rb
@@ -21,6 +21,33 @@ class RailsPulse::TaggableTest < ActiveSupport::TestCase
     assert_not_includes RailsPulse::Route.with_tag("api"), @untagged
   end
 
+  # SQLite has no default LIKE escape character, so `_` in a tag was a wildcard
+  # (and the escaped `\_` a literal backslash) until the ESCAPE clause was made
+  # explicit. Both cases must behave identically on every adapter.
+  test "with_tag matches an underscore literally" do
+    underscored = RailsPulse::Route.create!(http_methods: '["GET"]', path: "/taggable_test/underscored", tags: '["team_a"]')
+    lookalike   = RailsPulse::Route.create!(http_methods: '["GET"]', path: "/taggable_test/lookalike",  tags: '["teamxa"]')
+
+    results = RailsPulse::Route.with_tag("team_a")
+
+    assert_includes results, underscored
+    assert_not_includes results, lookalike
+  end
+
+  test "without_tag excludes an underscored tag literally" do
+    underscored = RailsPulse::Route.create!(http_methods: '["GET"]', path: "/taggable_test/underscored", tags: '["team_a"]')
+    lookalike   = RailsPulse::Route.create!(http_methods: '["GET"]', path: "/taggable_test/lookalike",  tags: '["teamxa"]')
+
+    results = RailsPulse::Route.without_tag("team_a")
+
+    assert_not_includes results, underscored
+    assert_includes results, lookalike
+  end
+
+  test "with_tag treats a percent sign literally" do
+    assert_empty RailsPulse::Route.with_tag("%")
+  end
+
   # without_tag
 
   test "without_tag excludes records that have the exact tag" do

--- a/test/models/rails_pulse/deployment_test.rb
+++ b/test/models/rails_pulse/deployment_test.rb
@@ -32,6 +32,41 @@ module RailsPulse
       assert_includes deployment.errors[:started_at], "can't be blank"
     end
 
+    test "validates revision length" do
+      deployment = Deployment.new(revision: "a" * 256, started_at: Time.current)
+
+      refute_predicate deployment, :valid?
+      assert_includes deployment.errors[:revision].join, "too long"
+    end
+
+    test "accepts a full 40-character sha with room to spare" do
+      assert_predicate Deployment.new(revision: "a" * 255, started_at: Time.current), :valid?
+    end
+
+    test "rejects started_at more than an hour in the future" do
+      deployment = Deployment.new(revision: "future", started_at: 2.hours.from_now)
+
+      refute_predicate deployment, :valid?
+      assert_includes deployment.errors[:started_at].join, "future"
+    end
+
+    test "allows started_at within clock skew" do
+      assert_predicate Deployment.new(revision: "soon", started_at: 30.minutes.from_now), :valid?
+    end
+
+    test "rejects metadata larger than 4 KB" do
+      deployment = Deployment.new(revision: "big", started_at: Time.current, metadata: { blob: "x" * 5_000 }.to_json)
+
+      refute_predicate deployment, :valid?
+      assert_includes deployment.errors[:metadata].join, "too large"
+    end
+
+    test "allows small metadata" do
+      deployment = Deployment.new(revision: "small", started_at: Time.current, metadata: { env: "production" }.to_json)
+
+      assert_predicate deployment, :valid?
+    end
+
     test "valid deployment saves successfully" do
       assert_difference -> { Deployment.count }, 1 do
         Deployment.create!(revision: "xyz999", started_at: Time.current)

--- a/test/services/rails_pulse/tag_filter_service_test.rb
+++ b/test/services/rails_pulse/tag_filter_service_test.rb
@@ -21,6 +21,16 @@ module RailsPulse
       assert_not_includes ids, tagged_route.id
     end
 
+    test "filter_ids excludes an underscored tag literally on every adapter" do
+      underscored = Route.create!(http_methods: '["GET"]', path: "/tag_filter/underscored", tags: '["team_a"]')
+      lookalike   = Route.create!(http_methods: '["GET"]', path: "/tag_filter/lookalike",  tags: '["teamxa"]')
+
+      ids = TagFilterService.filter_ids(Route, [ "team_a" ], true)
+
+      assert_not_includes ids, underscored.id
+      assert_includes ids, lookalike.id
+    end
+
     test "filter_ids includes non-tagged items when show_non_tagged is true" do
       # Routes without tags should be included
       all_routes = Route.pluck(:id)

--- a/test/support/global_filters_helpers.rb
+++ b/test/support/global_filters_helpers.rb
@@ -79,9 +79,9 @@ module GlobalFiltersHelpers
   end
 
   def assert_time_range_label(expected_text)
-    label = find('[data-rails-pulse--time-range-target="label"]')
-
-    assert_includes label.text, expected_text
+    # Use a waiting matcher: after switching ranges the page reloads, and a
+    # one-shot find + text comparison races the old page's label.
+    assert_selector '[data-rails-pulse--time-range-target="label"]', text: expected_text, wait: 5
   end
 
   def close_custom_range_modal

--- a/test/system/global_filters_test.rb
+++ b/test/system/global_filters_test.rb
@@ -13,15 +13,16 @@ class GlobalFiltersTest < ApplicationSystemTestCase
     @report_job = rails_pulse_jobs(:report_job)
 
     # Configure tags for testing
+    @original_tags = RailsPulse.configuration.tags
     RailsPulse.configure do |config|
       config.tags = [ "api", "users", "posts", "maintenance", "database", "critical" ]
     end
   end
 
   def teardown
-    # Reset configuration
+    # Restore the dummy app's configured tags
     RailsPulse.configure do |config|
-      config.tags = []
+      config.tags = @original_tags
     end
     super
   end

--- a/test/system/tags_test.rb
+++ b/test/system/tags_test.rb
@@ -6,15 +6,16 @@ class TagsTest < ApplicationSystemTestCase
     @job = rails_pulse_jobs(:mailer_job)
 
     # Configure tags for testing
+    @original_tags = RailsPulse.configuration.tags
     RailsPulse.configure do |config|
       config.tags = [ "critical", "monitoring", "scheduled" ]
     end
   end
 
   def teardown
-    # Reset configuration
+    # Restore the dummy app's configured tags
     RailsPulse.configure do |config|
-      config.tags = []
+      config.tags = @original_tags
     end
     super
   end


### PR DESCRIPTION
Findings L1–L5 from the security audit, in one PR.

## L1 — Tag exclusion filters silently failed on SQLite for tags with `_`

`taggable.rb`, `tables/base.rb` and `tag_filter_service.rb` escaped the LIKE pattern with `sanitize_sql_like` but issued it **without an `ESCAPE` clause**. PostgreSQL and MySQL default the escape character to backslash; SQLite has none, so `my\_tag` matched a literal backslash there and "hide records tagged `my_tag`" hid nothing. All three now use `ESCAPE '!'` — `!` can never appear in a valid tag and needs no quoting on any adapter (MySQL and PostgreSQL disagree on how to quote `'\'`).

## L2 — Backtrace source viewer read any file under `Rails.root`

`frame_source_lines` was realpath-bounded to `Rails.root`, but inside it anything went: `config/initializers/*.rb` with inline keys, `config/database.yml`, `.env`, `tmp/`. Reads are now limited to `app/`, `lib/` and `config/routes.rb`, and to code extensions (`.rb .erb .rake .haml .slim .jbuilder`), matched on the resolved relative path so a directory merely named `app` elsewhere does not qualify. (The `RawData` export shares the helper, so it is covered too.)

## L3 — Deployments API had no size caps and no cleanup

With a leaked CI token: `revision` was unbounded, `permit(metadata: {})` accepted arbitrarily nested JSON, `started_at` was caller-controlled (a future marker stamps every later exception with a revision that never shipped), and `rails_pulse_deployments` was in neither `max_table_records` nor `CleanupService`. Now: revision ≤ 255, metadata ≤ 4 KB serialized, `started_at` ≤ 1 h in the future, and a count cap (default 1 000, oldest-first) in `CleanupService`. Deployments are deliberately never pruned by age — a marker still explains summaries older than retention. Template, dummy app and `ConfigUpdater` (via the template) carry the new key.

## L4 — Standalone dashboard cookie and dead branch

- Session cookie is `Secure` in production (`RAILS_PULSE_INSECURE_SESSION=1` opts out for a private non-TLS network) and explicitly `HttpOnly`. rack-session refuses to write a Secure cookie over plain HTTP, and there's a test asserting exactly that.
- The rackup's "no Rails app" branch could never boot (`NameError: uninitialized constant Rails` — re-verified). It's replaced by an `abort` printing the working invocation. `docs/deployment-modes.md` now gives that invocation (`$(bundle show rails_pulse)/lib/rails_pulse_server.ru` from the app root) instead of `rackup lib/rails_pulse_server.ru` from the app directory, where the path doesn't exist, and explains why `RAILS_ENV=production` matters (it enables authentication).

## L5 — Hand-edited query strings returned 500s

- New `RansackParamsConcern#ransack_params` normalises `params[:q]` once; `?q=string` no longer calls Hash methods on a String across seven call sites.
- Custom date ranges, chart-zoom bounds and session time filters fall back to defaults when they don't parse (`parse_time_param` returns nil instead of raising).
- `Operation`'s `occurred_at` Ransack formatter returns nil (= no filter) on garbage instead of raising.
- `set_global_filters` / `set_time_range`: `enabled_tags` coerced to an array; presets and performance thresholds validated against their known values; time strings must parse and be ≤ 64 chars before entering the 4 KB cookie session (`Time.parse` itself raises above 128).

## Tests

Underscore/percent literal matching in `Taggable` and `TagFilterService`; source allow-list (app/ ok, routes.rb ok, initializers/tmp/yml/outside-root refused); deployment validations at model and controller level; count-cap and never-by-age cleanup; secure/HttpOnly/opt-out/no-cookie-over-HTTP for the standalone server; unparseable ranges/zoom/session filters and `q=string` in the time-range concern and in the requests, exceptions and deployments controllers; session-input validation in `ApplicationController`.

`PARALLEL_WORKERS=1 DB=sqlite3 bin/rails test`: 3305 runs, 0 errors, 1 pre-existing order-dependent failure in `upgrade_migration_test` (passes alone on both this branch and `main`). RuboCop clean. Brakeman shows the same two pre-existing warnings as `main` (re-triaged in #217).

**Not verified locally:** PostgreSQL and MySQL aren't running on this machine, so the `ESCAPE '!'` change is only exercised on SQLite here — the CI matrix covers the other two. The clause is standard SQL and `!` needs no quoting on either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BaximWeiDUL64Mr5RXWi4n
