### PR TITLE
Fix upgrade generator escaping and keep tracker off shared test connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`rails generate rails_pulse:upgrade` wrote a migration that would not parse.**
+  The schema parser matched a column comment with `comment: "([^"]*)"`, which stops
+  at the first escaped quote. The `http_methods` comment embeds a `["GET","POST"]`
+  example, so it was truncated mid-escape and the trailing backslash escaped the
+  closing quote of the generated `comment:` string — the copied
+  `upgrade_rails_pulse_tables.rb` then failed to load with
+  `unterminated string meets end of file`. Comments are now matched as complete Ruby
+  string literals, decoded with `String#undump`, and re-escaped with `String#inspect`
+  when the migration is rendered.
+
 ## [0.4.0.pre.1] - 2026-09-03
 
 This release contains a **breaking schema change** and requires a one-time data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   string literals, decoded with `String#undump`, and re-escaped with `String#inspect`
   when the migration is rendered.
 
+- **Background tracking writes corrupted the host app's test database connection.**
+  Under `use_transactional_tests` Rails pins one connection per pool and hands that
+  same connection to every thread, so the tracker's writer thread interleaved its
+  INSERTs with the test's own statements on a single socket. PostgreSQL reported
+  this as `message type 0x5a arrived from server while idle` and
+  `server sent data ("D" message) without prior row description`, and suites hung
+  or failed at random. The gem's own dummy app avoided it with
+  `config.async = false if Rails.env.test?`, but the installed initializer never
+  shipped that line. The tracker now writes inline whenever the pool's connection
+  is shared across threads, and `rails generate rails_pulse:install` adds the
+  test-environment line to the initializer. Existing installs should add
+  `config.async = false if Rails.env.test?` to `config/initializers/rails_pulse.rb`.
+
 ## [0.4.0.pre.1] - 2026-09-03
 
 This release contains a **breaking schema change** and requires a one-time data

--- a/docs/deployment-modes.md
+++ b/docs/deployment-modes.md
@@ -161,17 +161,15 @@ server {
 
 ## Tracking Behavior
 
-Rails Pulse uses **async tracking** by default in all environments for minimal performance overhead:
+Rails Pulse persists tracking data on a background thread by default (`config.async = true`), so the database writes for a request do not hold up its response.
 
-- **Production/Development:** Uses fiber-based async tracking (via `async` gem)
-- **Test:** Runs synchronously for predictability and easier debugging
-
-This is handled automatically and requires no configuration.
+- **Production/Development:** writes happen on a background thread once the response has been built
+- **Test:** writes happen inline. The generated initializer sets `config.async = false if Rails.env.test?`, and the tracker also falls back to inline writes on its own whenever it detects a transactional-test connection, because Rails shares that single connection with every thread
 
 **Performance Impact:**
-- Async mode: ~0.1ms overhead per request
-- Database writes happen in background fibers
-- Non-blocking for request processing
+- The request thread only hands the collected data to the writer thread
+- Database writes happen off the request thread
+- Set `config.async = false` to write inline before the response is sent
 
 ---
 

--- a/lib/generators/rails_pulse/schema_parser.rb
+++ b/lib/generators/rails_pulse/schema_parser.rb
@@ -48,6 +48,25 @@ module RailsPulse
 
       private
 
+      # Column definitions look like: t.text :column_name, comment: "..."
+      # The comment capture must tolerate escaped quotes — the http_methods
+      # comment embeds a JSON example, [\"GET\",\"POST\"] — so it matches a
+      # full Ruby string literal (quotes included) rather than stopping at the
+      # first quote character.
+      COLUMN_DEFINITION = /t\.(\w+)\s+:([a-zA-Z_][a-zA-Z0-9_]*)(?:.*?comment:\s*("(?:[^"\\]|\\.)*"))?/
+
+      # Turn the matched Ruby string literal back into the string it denotes, so
+      # callers hold the real comment text and re-escape it themselves (the
+      # upgrade migration template uses String#inspect). Falls back to stripping
+      # the quotes if the literal uses an escape String#undump rejects.
+      def decode_comment(literal)
+        return nil if literal.nil?
+
+        literal.undump
+      rescue RuntimeError
+        literal.delete_prefix('"').delete_suffix('"')
+      end
+
       # Parse column definitions from a table block
       # Returns hash of column_name => { type:, comment: }
       def parse_table_columns(table_block)
@@ -55,9 +74,10 @@ module RailsPulse
 
         table_block.split("\n").each do |line|
           # Match column definitions: t.text :column_name, comment: "..."
-          next unless match = line.match(/t\.(\w+)\s+:([a-zA-Z_][a-zA-Z0-9_]*)(?:.*?comment:\s*"([^"]*)")?/)
+          next unless match = line.match(COLUMN_DEFINITION)
 
-          column_type, column_name, comment = match.captures
+          column_type, column_name, comment_literal = match.captures
+          comment = decode_comment(comment_literal)
 
           # Skip timestamps and references (Rails handles these)
           next if %w[timestamps references].include?(column_type)

--- a/lib/generators/rails_pulse/templates/migrations/upgrade_rails_pulse_tables.rb
+++ b/lib/generators/rails_pulse/templates/migrations/upgrade_rails_pulse_tables.rb
@@ -4,7 +4,7 @@ class UpgradeRailsPulseTables < ActiveRecord::Migration[<%= @migration_version %
     <% @missing_columns.each do |table_name, columns| %>
       <% columns.each do |column_name, definition| %>
     # Add <%= column_name %> column to <%= table_name %>
-    add_column :<%= table_name %>, :<%= column_name %>, :<%= definition[:type] %><% if definition[:comment] %>, comment: "<%= definition[:comment] %>"<% end %>
+    add_column :<%= table_name %>, :<%= column_name %>, :<%= definition[:type] %><% if definition[:comment] %>, comment: <%= definition[:comment].inspect %><% end %>
       <% end %>
     <% end %>
   end

--- a/lib/generators/rails_pulse/templates/rails_pulse.rb
+++ b/lib/generators/rails_pulse/templates/rails_pulse.rb
@@ -6,6 +6,11 @@ RailsPulse.configure do |config|
   # Enable or disable Rails Pulse
   config.enabled = true
 
+  # Tracking writes happen on a background thread by default (see `config.async`
+  # under ADVANCED). Transactional tests share one database connection across
+  # threads, so write inline there to keep the writer off the test's connection.
+  config.async = false if Rails.env.test?
+
   # ====================================================================================================
   #                                               THRESHOLDS
   # ====================================================================================================

--- a/lib/rails_pulse/tracker.rb
+++ b/lib/rails_pulse/tracker.rb
@@ -11,7 +11,7 @@ module RailsPulse
       def track_request(data)
         return if RequestStore.store[:skip_recording_rails_pulse_activity]
 
-        if RailsPulse.configuration.async
+        if RailsPulse.configuration.async && !connection_shared_across_threads?
           Thread.new do
             perform_tracking(data)
           rescue => e
@@ -60,6 +60,22 @@ module RailsPulse
         nil
       ensure
         RequestStore.store[:skip_recording_rails_pulse_activity] = false
+      end
+
+      # Transactional tests pin one connection per pool and hand that same
+      # connection to every thread that asks for one. A background writer would
+      # then interleave its statements with the test's on a single socket, which
+      # PostgreSQL reports as "message type 0x5a arrived from server while idle".
+      # Rails 7.2+ records the pin in the pool's @pinned_connection; 7.1 sets a
+      # @lock_thread on the pool instead. Neither is public API, so read both
+      # defensively and treat any failure as "not shared".
+      def connection_shared_across_threads?
+        pool = RailsPulse::ApplicationRecord.connection_pool
+        return true if pool.instance_variable_get(:@pinned_connection)
+
+        pool.instance_variable_get(:@lock_thread) ? true : false
+      rescue StandardError
+        false
       end
 
       def clear_aborted_transaction(conn)

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -40,6 +40,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
       assert_match(/RailsPulse.configure/, content)
       assert_match(/schema_dump: false/, content)
       assert_match(/migrations_paths: db\/rails_pulse_migrate/, content)
+      assert_match(/config\.async = false if Rails\.env\.test\?/, content)
     end
   end
 

--- a/test/generators/schema_parser_test.rb
+++ b/test/generators/schema_parser_test.rb
@@ -63,6 +63,14 @@ module RailsPulse
         assert_match(/HTTP methods/, routes["http_methods"][:comment])
       end
 
+      test "preserves escaped quotes inside column comments" do
+        schema = @parser.extract_expected_schema
+        routes = schema["rails_pulse_routes"]
+
+        assert_equal 'JSON array of HTTP methods accepted by this route (e.g., ["GET","POST"])',
+          routes["http_methods"][:comment]
+      end
+
       test "skips timestamps columns" do
         schema = @parser.extract_expected_schema
         routes = schema["rails_pulse_routes"]
@@ -95,6 +103,21 @@ module RailsPulse
           schema = parser.extract_expected_schema
 
           assert_empty schema
+        end
+      end
+
+      test "falls back to the raw comment when the literal holds an escape undump rejects" do
+        Dir.mktmpdir do |dir|
+          schema_file = File.join(dir, "schema.rb")
+          File.write(schema_file, <<~RUBY)
+            connection.create_table :rails_pulse_routes do |t|
+              t.string :path, comment: "bad escape \\x"
+            end
+          RUBY
+
+          schema = SchemaParser.new(schema_file).extract_expected_schema
+
+          assert_equal 'bad escape \\x', schema["rails_pulse_routes"]["path"][:comment]
         end
       end
 

--- a/test/generators/upgrade_generator_test.rb
+++ b/test/generators/upgrade_generator_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 require "generators/rails_pulse/upgrade_generator"
 require_relative "../support/generator_test_helpers"
 require "ostruct"
+require "ripper"
 
 class UpgradeGeneratorTest < Rails::Generators::TestCase
   include GeneratorTestHelpers
@@ -285,6 +286,20 @@ test "separate database upgrade copies migrations to rails_pulse_migrate" do
     assert_match(/Creating upgrade migration for missing columns/, output)
     assert_migration "db/migrate/upgrade_rails_pulse_tables.rb" do |content|
       assert_match(/add_column :rails_pulse_routes, :tags, :text/, content)
+    end
+  end
+
+  test "generated migration escapes quotes inside column comments" do
+    File.write(File.join(destination_root, "config/database.yml"), single_database_yml)
+
+    mock_tables_with_missing_columns do
+      run_generator([], {})
+    end
+
+    assert_migration "db/migrate/upgrade_rails_pulse_tables.rb" do |content|
+      assert_includes content,
+        %{comment: "JSON array of HTTP methods accepted by this route (e.g., [\\"GET\\",\\"POST\\"])"}
+      assert_not_nil Ripper.sexp(content), "Generated migration is not valid Ruby:\n#{content}"
     end
   end
 

--- a/test/tracker_test.rb
+++ b/test/tracker_test.rb
@@ -126,6 +126,33 @@ class RailsPulse::TrackerTest < ActiveSupport::TestCase
     end
   end
 
+  # use_transactional_tests pins this pool's connection and shares it with every
+  # thread, so a background writer would race the test on the same socket.
+  test "writes inline under a shared test connection even when async is enabled" do
+    original_async = RailsPulse.configuration.async
+    RailsPulse.configuration.async = true
+    Thread.expects(:new).never
+
+    result = RailsPulse::Tracker.track_request(@tracking_data)
+
+    assert_kind_of RailsPulse::Request, result
+    assert_not_nil RailsPulse::Request.find_by(request_uuid: @tracking_data[:request_uuid])
+  ensure
+    RailsPulse.configuration.async = original_async
+  end
+
+  test "spawns a background thread when async is enabled and the connection is not shared" do
+    original_async = RailsPulse.configuration.async
+    RailsPulse.configuration.async = true
+    RailsPulse::Tracker.stubs(:connection_shared_across_threads?).returns(false)
+    Thread.expects(:new).once
+
+    assert_nil RailsPulse::Tracker.track_request(@tracking_data)
+  ensure
+    RailsPulse.configuration.async = original_async
+    RailsPulse::Tracker.unstub(:connection_shared_across_threads?)
+  end
+
   test "persists response_size_bytes to request record" do
     data = @tracking_data.merge(response_size_bytes: 4096)
     RailsPulse::Tracker.track_request(data)


### PR DESCRIPTION
Two fixes:

- **Upgrade generator emitted an unparseable migration.** The schema parser truncated column comments at the first escaped quote (the `http_methods` comment embeds `["GET","POST"]`), producing a migration that failed to load. Comments are now matched as full Ruby string literals, decoded with `String#undump`, and re-escaped with `String#inspect` when the migration is rendered.

- **Background tracking writes corrupted the host app's test database connection.** Transactional tests pin one connection and share it across threads, so the tracker's writer thread interleaved statements with the test's own. The tracker now writes inline whenever it detects a shared connection, and the install generator adds `config.async = false if Rails.env.test?` to the initializer.