### PR TITLE
Tidy up test suite output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Cleaned up test suite output.** A green `rake test` run no longer prints RDoc
+  constant-redefinition warnings, stray blank lines from a leftover progress `puts`,
+  leaked log/rake-task output, a "missing assertions" warning, or a seed-dependent
+  skip — the full run is now a clean ~35-line report.
+
 ## [0.4.0.pre.2] - 2026-09-04
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GEM
       dotenv (= 3.1.8)
       railties (>= 6.1)
     drb (2.2.3)
-    erb (6.0.4)
+    erb (6.0.7)
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
@@ -223,10 +223,7 @@ GEM
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
-    prism (1.4.0)
-    psych (5.3.1)
-      date
-      stringio
+    prism (1.9.0)
     public_suffix (7.0.5)
     puma (6.6.1)
       nio4r (~> 2.0)
@@ -284,9 +281,14 @@ GEM
       activerecord (>= 6.1.5)
       activesupport (>= 6.1.5)
       i18n
-    rdoc (7.2.0)
+    rbs (4.2.0)
+      logger
+      prism (>= 1.6.0)
+      tsort
+    rdoc (8.0.0)
       erb
-      psych (>= 4.0.0)
+      prism (>= 1.6.0)
+      rbs (>= 4.0.0)
       tsort
     redis (5.4.1)
       redis-client (>= 0.22.0)
@@ -320,9 +322,9 @@ GEM
       ruby-progressbar (~> 1.7)
       tsort (>= 0.2.0)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.46.0)
+    rubocop-ast (1.50.0)
       parser (>= 3.3.7.2)
-      prism (~> 1.4)
+      prism (~> 1.7)
     rubocop-minitest (0.38.2)
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
@@ -387,7 +389,6 @@ GEM
     sqlite3 (2.9.5-x86_64-darwin)
     sqlite3 (2.9.5-x86_64-linux-gnu)
     sqlite3 (2.9.5-x86_64-linux-musl)
-    stringio (3.2.0)
     thor (1.5.0)
     tilt (2.7.0)
     timecop (0.9.10)

--- a/Rakefile
+++ b/Rakefile
@@ -120,7 +120,7 @@ task :test_migrations do
   # Migration regression tests run DDL against historical schema snapshots;
   # coverage is meaningless there, and the SimpleCov per-file gate would fail
   # on rake task files that load but never execute in that process.
-  sh({ "COVERAGE" => nil }, "rails test test/migrations")
+  sh({ "COVERAGE" => nil }, "rails test test/migrations", verbose: false)
 end
 
 desc "Run test suite"
@@ -149,7 +149,7 @@ task :test do
   puts "=" * 50
   puts
 
-  sh "rails test test/controllers test/generators test/helpers test/instrumentation test/jobs test/lib test/middleware test/models test/services test/rails_pulse_test.rb test/tracker_test.rb"
+  sh "rails test test/controllers test/generators test/helpers test/instrumentation test/jobs test/lib test/middleware test/models test/services test/rails_pulse_test.rb test/tracker_test.rb", verbose: false
   Rake::Task[:test_migrations].invoke
 end
 

--- a/app/services/rails_pulse/route_controller_action_backfiller.rb
+++ b/app/services/rails_pulse/route_controller_action_backfiller.rb
@@ -6,13 +6,9 @@ module RailsPulse
 
     def call
       results = { updated: 0, skipped: 0, already_set: 0, merged: 0 }
-      total = RailsPulse::Route.count
-      processed = 0
       RailsPulse::Route.find_each do |route|
         process_route(route, results)
-        processed += 1
       end
-      puts "" if total > 0
       consolidate_unrecognized_duplicates(results)
       results
     end

--- a/test/dummy/Gemfile.lock
+++ b/test/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    rails_pulse (0.4.0.pre.1)
+    rails_pulse (0.4.0.pre.2)
       rails (>= 7.1.0, < 9.0.0)
       ransack (~> 4.0)
       request_store (~> 1.5)
@@ -101,7 +101,7 @@ GEM
       dotenv (= 3.1.8)
       railties (>= 6.1)
     drb (2.2.3)
-    erb (6.0.4)
+    erb (6.0.7)
     erubi (1.13.1)
     globalid (1.4.0)
       activesupport (>= 6.1)
@@ -167,9 +167,6 @@ GEM
     pry-byebug (3.11.0)
       byebug (~> 12.0)
       pry (>= 0.13, < 0.16)
-    psych (5.3.1)
-      date
-      stringio
     puma (7.2.1)
       nio4r (~> 2.0)
     racc (1.8.1)
@@ -216,9 +213,14 @@ GEM
       activerecord (>= 6.1.5)
       activesupport (>= 6.1.5)
       i18n
-    rdoc (7.2.0)
+    rbs (4.2.0)
+      logger
+      prism (>= 1.6.0)
+      tsort
+    rdoc (8.0.0)
       erb
-      psych (>= 4.0.0)
+      prism (>= 1.6.0)
+      rbs (>= 4.0.0)
       tsort
     reline (0.6.3)
       io-console (~> 0.5)
@@ -233,7 +235,6 @@ GEM
     sqlite3 (2.9.5-x86_64-darwin)
     sqlite3 (2.9.5-x86_64-linux-gnu)
     sqlite3 (2.9.5-x86_64-linux-musl)
-    stringio (3.2.0)
     thor (1.5.0)
     timeout (0.6.1)
     tsort (0.2.0)

--- a/test/lib/rails_pulse/configuration_test.rb
+++ b/test/lib/rails_pulse/configuration_test.rb
@@ -488,7 +488,9 @@ module RailsPulse
       RailsPulse.instance_variable_set(:@logger, nil)
 
       begin
-        assert_nothing_raised { config.validate_configuration! }
+        out, _err = capture_io { config.validate_configuration! }
+
+        assert_match(/no authentication method is configured/, out)
       ensure
         Rails.logger = original_logger
         RailsPulse.instance_variable_set(:@logger, nil)

--- a/test/lib/tasks/rails_pulse_test.rb
+++ b/test/lib/tasks/rails_pulse_test.rb
@@ -294,14 +294,16 @@ class RailsPulseRakeTest < ActiveSupport::TestCase
       conn.stubs(:table_exists?).with(:schema_migrations).returns(false)
       table = mock("table")
       table.stubs(:string).with(:version, null: false)
-      conn.stubs(:create_table).with(:schema_migrations, id: false).yields(table)
-      conn.stubs(:add_index).with(:schema_migrations, :version, unique: true, name: "unique_schema_migrations")
+      conn.expects(:create_table).with(:schema_migrations, id: false).yields(table)
+      conn.expects(:add_index).with(:schema_migrations, :version, unique: true, name: "unique_schema_migrations")
       conn.stubs(:select_values).returns([])
       conn.stubs(:quote).returns("'20260101000000'")
       conn.stubs(:execute)
       RailsPulse::ApplicationRecord.stubs(:connection).returns(conn)
 
-      record_rails_pulse_migrations_applied
+      output = capture_stdout { record_rails_pulse_migrations_applied }
+
+      assert_includes output, "Marked migration 20260101000000 as applied"
     end
   end
 

--- a/test/models/rails_pulse/routes/charts/response_time_percentiles_test.rb
+++ b/test/models/rails_pulse/routes/charts/response_time_percentiles_test.rb
@@ -138,8 +138,10 @@ module RailsPulse
         end
 
         test "includes SLO series when configured" do
-          # Skip if no SLOs configured
-          skip if RailsPulse.configuration.service_level_objectives.empty?
+          original_config = RailsPulse.configuration.service_level_objectives
+          RailsPulse.configuration.service_level_objectives = [
+            { percentile: 95, threshold: 200 }
+          ]
 
           chart = ResponseTimePercentiles.new(
             ransack_query: @ransack_query,
@@ -152,6 +154,8 @@ module RailsPulse
           series_names = data[:series].map { |s| s[:name] }
 
           assert series_names.any? { |name| name.match?(/P\d+ SLO \(\d+ms\)/) }
+        ensure
+          RailsPulse.configuration.service_level_objectives = original_config
         end
 
         test "renders one SLO line per configured SLO entry" do


### PR DESCRIPTION
A green `rake test` run used to produce ~167 lines of noise — RDoc warnings, stray blank lines, leaked log output, a minitest warning, and a seed-dependent skip. This trims it to a clean 35-line report.

## Changes

- **RDoc constant-redefinition warnings (~48 lines)**: `bundle update rdoc` in both the gem root and `test/dummy` lockfiles so the bundled version (8.0.0) matches the newest installed gem. Previously RubyGems loaded 8.0.0 pre-bundler, then the locked 7.2.0 redefined all its constants — 16 warnings printed once per test process. Also pulls in rdoc's new deps (rbs, prism 1.9) and bumps rubocop-ast to satisfy the prism constraint.
- **~40 stray blank lines**: removed a leftover progress `puts ""` (and the dead `total`/`processed` counters) from `RouteControllerActionBackfiller#call`, which printed a newline into the dot stream for every test exercising it.
- **Leaked authentication WARN**: the "tolerates nil Rails.logger" configuration test now wraps validation in `capture_io` and asserts on the warning text instead of letting it hit stdout via the `Logger.new($stdout)` fallback.
- **Leaked `[RailsPulse] Marked migration` line + "Test is missing assertions"**: the schema_migrations-creation task test now uses `capture_stdout` like its sibling tests, asserts on the output, and upgrades its key stubs to `expects` — fixing both issues at once.
- **Seed-dependent skip**: "includes SLO series when configured" skipped whenever ambient SLO config was empty (dependent on test ordering across parallel workers). It now configures its own SLOs with an `ensure` restore, so it always runs deterministically.
- **Echoed command lines**: the two `sh "rails test ..."` calls in the Rakefile pass `verbose: false`, so rake no longer prints the raw commands above the suite banners.

Also syncs `test/dummy/Gemfile.lock` with the `0.4.0.pre.2` version bump.

## Verification

Full `DB=sqlite3 rake test`: 3343 runs, 9000 assertions, 0 failures, 0 errors, 0 skips — with zero warnings or stray output. RuboCop clean on all changed files.