### PR TITLE
Update puma to 7.2.1 (PROXY protocol security fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Development dependencies: puma updated to 7.2.1** in the gem's own `Gemfile`
+  and `Gemfile.lock` (pinned to match the dummy app), resolving two high-severity
+  advisories in the PROXY protocol v1 parser: remote memory exhaustion, and
+  repeated protocol headers accepted on persistent connections. Puma is a
+  test-only dependency of the gem; host apps are unaffected.
+
 ## [0.4.0.pre.2] - 2026-09-04
 
 ### Fixed

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "dotenv-rails", groups: [ :development, :test ]
 # Testing dependencies
 group :test do
   gem "appraisal"
-  gem "puma"
+  gem "puma", "7.2.1"
   gem "capybara"
   gem "minitest-reporters"
   gem "mocha"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,7 +228,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (6.6.1)
+    puma (7.2.1)
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
@@ -435,7 +435,7 @@ DEPENDENCIES
   mysql2 (~> 0.5)
   ostruct
   pg (>= 1.1)
-  puma
+  puma (= 7.2.1)
   rails-controller-testing (>= 1.0)
   rails_pulse!
   resque


### PR DESCRIPTION
Resolves **two high-severity** Dependabot alerts for `puma` (`>= 5.5.0, < 7.2.1`):

- *PROXY Protocol v1 Parser Allows Remote Memory Exhaustion*
- *PROXY Protocol v1 Accepts Repeated Protocol Headers on Persistent Connections*

Updates puma 6.6.1 → 7.2.1 in the root `Gemfile.lock`, pinned in the `Gemfile` to match the exact version `test/dummy` already pins and runs. An unpinned `bundle update` would have jumped to puma 8.0.2; staying on the proven 7.2.1 keeps the CI system-test job on the same version the dummy app uses. Puma is a test-only dependency of the gem — host apps are unaffected.

Full `DB=sqlite3 rake test`: 3343 runs, 0 failures, 0 errors, 0 skips.