### PR TITLE
Update websocket-driver to 0.8.2 (Host header DoS fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Development dependencies: websocket-driver updated to 0.8.2** in the gem's own
+  `Gemfile.lock`, resolving a high-severity advisory (denial of service via a
+  malformed Host header). This lockfile only affects development/CI of the gem
+  itself; host apps resolve their own version.
+
 ## [0.4.0.pre.2] - 2026-09-04
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -401,7 +401,7 @@ GEM
     uri (1.1.1)
     useragent (0.16.11)
     websocket (1.2.11)
-    websocket-driver (0.8.0)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)


### PR DESCRIPTION
Resolves the **high-severity** Dependabot alert for `websocket-driver` (`< 0.8.2`): *denial of service via malformed Host header.*

Updates websocket-driver 0.8.0 → 0.8.2 in the root `Gemfile.lock` (only gem touched). It's a transitive dependency of Action Cable in the gem's development bundle — host apps resolve their own version. `test/dummy/Gemfile.lock` is already on 0.8.2.

Full `DB=sqlite3 rake test`: 3343 runs, 0 failures, 0 errors, 0 skips.