### PR TITLE
Update concurrent-ruby to 1.3.8 (AtomicReference livelock fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Development dependencies: concurrent-ruby updated to 1.3.8** in the gem's own
+  `Gemfile.lock`, resolving a high-severity advisory (`AtomicReference#update`
+  livelocks when the stored value is `Float::NAN`). This lockfile only affects
+  development/CI of the gem itself; host apps resolve their own version.
+
 ## [0.4.0.pre.2] - 2026-09-04
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,7 +106,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.8)
     connection_pool (3.0.2)
     crass (1.0.6)
     css-zero (1.1.15)


### PR DESCRIPTION
Resolves the **high-severity** Dependabot alert for `concurrent-ruby` (`< 1.3.7`): *`AtomicReference#update` livelocks when the stored value is `Float::NAN`.*

Updates concurrent-ruby 1.3.6 → 1.3.8 in the root `Gemfile.lock` (only gem touched; 1.3.8 is the latest patch past the fixed 1.3.7). It's a transitive dependency of Active Support in the gem's development bundle — host apps resolve their own version. `test/dummy/Gemfile.lock` is already on 1.3.8.

Full `DB=sqlite3 rake test`: 3343 runs, 0 failures, 0 errors. (The 1 skip is the seed-dependent SLO-config skip present on main, fixed separately in #225.)