### PR TITLE
Fix standalone dashboard server: assets, Rack 3 headers, env passthrough, secret fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   accepts. A new `rake rails_pulse:finish_deployment[revision]` sets `finished_at` on the
   latest deployment for that revision, so release scripts can close a deployment without
   a token or network access to the dashboard.
+### Fixed
+
+- **The standalone dashboard server now serves its own assets.** `rails_pulse_server.ru`
+  calls the engine directly, bypassing the host middleware stack — which is where
+  `RailsPulse::Middleware::AssetServer` (the `/rails-pulse-assets/...` fallback) and
+  `ActionDispatch::Static` (the digested `/assets/...` copies that `assets:precompile`
+  installs) live. Every standalone page therefore rendered with 404s for its stylesheet
+  and scripts. The rackup now serves both paths itself.
+- **Asset responses are Rack 3 compliant.** `Engine.asset_headers` and
+  `AssetServer#cache_headers` used mixed-case header names (`Cache-Control`, `Vary`,
+  `Expires`, `Pragma`). Rack 3 requires lowercase, and `Rack::Lint` — which `rackup`
+  inserts in its development environment — turned every asset request into a 500.
+- **`rails_pulse_server` passes the environment through to `rackup`.** `rackup`
+  defaults to its own `development` environment regardless of `RAILS_ENV`, wrapping the
+  dashboard in `Rack::Lint` and `Rack::ShowExceptions` in production. The executable now
+  passes `-E` from `RACK_ENV`, then `RAILS_ENV`, unless given explicitly.
+- **The standalone server falls back to the host's `secret_key_base`.** It required a
+  literal `SECRET_KEY_BASE` environment variable, which hosts on encrypted credentials do
+  not have, even though `config/environment.rb` (and so
+  `Rails.application.secret_key_base`) was already loaded. It still refuses to boot when
+  neither is available.
+
 ### Security
 
 - **Development dependencies: mail stack and json updated**: mail 2.9.0 → 2.9.1

--- a/docs/deployment-modes.md
+++ b/docs/deployment-modes.md
@@ -85,8 +85,10 @@ the development database.
 
 Two environment variables are required or strongly recommended:
 
-- `SECRET_KEY_BASE` — the server refuses to start without it; it signs the
-  dashboard's session cookie.
+- `SECRET_KEY_BASE` — signs the dashboard's session cookie. When it is not
+  set the server falls back to the host app's `secret_key_base` (from
+  encrypted credentials or `config/secrets`), and refuses to start only if
+  neither is available.
 - `RAILS_ENV=production` — see above.
 
 The session cookie is marked `Secure` in production, so it is only sent over

--- a/exe/rails_pulse_server
+++ b/exe/rails_pulse_server
@@ -21,5 +21,14 @@ unless args.any? { |arg| arg.start_with?("-p") || arg == "--port" }
   args.unshift("-p", port)
 end
 
+# rackup's own environment defaults to "development" regardless of RAILS_ENV,
+# and in that mode it wraps the app in Rack::Lint and Rack::ShowExceptions.
+# Follow RACK_ENV, then RAILS_ENV, so a production dashboard is served without
+# the development middleware (an explicit -E/--env still wins).
+rack_env = ENV["RACK_ENV"].to_s.empty? ? ENV["RAILS_ENV"] : ENV["RACK_ENV"]
+unless rack_env.to_s.empty? || args.any? { |arg| arg.start_with?("-E") || arg == "--env" }
+  args.unshift("-E", rack_env)
+end
+
 # Execute rackup with the server file
 exec("rackup", rackup_file, *args)

--- a/lib/rails_pulse/engine.rb
+++ b/lib/rails_pulse/engine.rb
@@ -149,10 +149,12 @@ module RailsPulse
 
     private
 
+    # Lowercase keys: Rack 3 requires them, and Rack::Lint (which rackup
+    # inserts in its development environment) rejects mixed case with a 500.
     def self.asset_headers
       {
-        "Cache-Control" => "public, max-age=31536000, immutable",
-        "Vary" => "Accept-Encoding"
+        "cache-control" => "public, max-age=31536000, immutable",
+        "vary" => "Accept-Encoding"
       }
     end
   end

--- a/lib/rails_pulse/middleware/asset_server.rb
+++ b/lib/rails_pulse/middleware/asset_server.rb
@@ -62,14 +62,15 @@ module RailsPulse
         path.to_s.sub(VERSIONED_ASSET_PATH, '\1')
       end
 
+      # Lowercase keys: Rack 3 requires them, and Rack::Lint rejects mixed case.
       def cache_headers
         if defined?(Rails) && Rails.env.development?
-          { "Cache-Control" => "no-cache, no-store, must-revalidate", "Pragma" => "no-cache" }
+          { "cache-control" => "no-cache, no-store, must-revalidate", "pragma" => "no-cache" }
         else
           {
-            "Cache-Control" => "public, max-age=31536000, immutable",
-            "Vary" => "Accept-Encoding",
-            "Expires" => (Time.now + 1.year).httpdate
+            "cache-control" => "public, max-age=31536000, immutable",
+            "vary" => "Accept-Encoding",
+            "expires" => (Time.now + 1.year).httpdate
           }
         end
       end

--- a/lib/rails_pulse_server.ru
+++ b/lib/rails_pulse_server.ru
@@ -25,8 +25,10 @@ $stderr.sync = true
 
 # Build the Rack app with session support
 require "rack/session/cookie"
+require "rack/static"
 require "securerandom"
 require_relative "rails_pulse/rack_compat"
+require_relative "rails_pulse/middleware/asset_server"
 
 # Simple Rack app that just serves the dashboard
 class DashboardApp
@@ -57,10 +59,38 @@ class DashboardApp
   end
 end
 
-# Add session middleware for the dashboard
-# Require SECRET_KEY_BASE for security
-secret_key = ENV.fetch("SECRET_KEY_BASE") do
-  raise "SECRET_KEY_BASE environment variable must be set for standalone dashboard"
+# Dashboard assets. RouteHelper#asset_path emits one of two URL shapes: the
+# gem-served fallback (/rails-pulse-assets/<version>/...) or, once
+# assets:precompile has run, the digested copies it installs under the host's
+# public/assets. In the main app those are served by AssetServer (inserted
+# into the host middleware stack by the engine) and by ActionDispatch::Static
+# or the CDN. This process calls the engine directly and has neither, so both
+# are served here; without them every dashboard page renders unstyled.
+use RailsPulse::Middleware::AssetServer,
+  RailsPulse::Engine.root.join("public").to_s,
+  urls: [ "/rails-pulse-assets" ],
+  headers: RailsPulse::Engine.asset_headers
+
+use Rack::Static,
+  urls: [ "/assets" ],
+  root: Rails.public_path.to_s,
+  header_rules: [ [ :all, RailsPulse::Engine.asset_headers ] ]
+
+# Add session middleware for the dashboard. The cookie is signed with
+# SECRET_KEY_BASE when set, otherwise with the host app's own secret_key_base
+# (config/environment.rb is already loaded above) — hosts on encrypted
+# credentials have no SECRET_KEY_BASE environment variable.
+secret_key = ENV["SECRET_KEY_BASE"].to_s
+if secret_key.empty?
+  secret_key = begin
+    Rails.application.secret_key_base.to_s
+  rescue StandardError
+    ""
+  end
+end
+if secret_key.empty?
+  raise "SECRET_KEY_BASE environment variable must be set for standalone dashboard " \
+        "(no Rails secret_key_base was available to fall back to)"
 end
 
 # `secure` keeps the session cookie off plain HTTP in production. Set

--- a/test/lib/rails_pulse/middleware/asset_server_test.rb
+++ b/test/lib/rails_pulse/middleware/asset_server_test.rb
@@ -84,7 +84,7 @@ module RailsPulse
 
         headers = @middleware.send(:cache_headers)
 
-        assert_includes headers["Cache-Control"], "immutable"
+        assert_includes headers["cache-control"], "immutable"
       ensure
         Rails.unstub(:env)
       end
@@ -94,7 +94,7 @@ module RailsPulse
 
         headers = @middleware.send(:cache_headers)
 
-        assert_includes headers["Cache-Control"], "no-cache"
+        assert_includes headers["cache-control"], "no-cache"
       ensure
         Rails.unstub(:env)
       end

--- a/test/lib/rails_pulse/standalone_server_test.rb
+++ b/test/lib/rails_pulse/standalone_server_test.rb
@@ -1,5 +1,6 @@
 require "test_helper"
 require "rack/mock_request"
+require "rack/lint"
 
 module RailsPulse
   class StandaloneServerTest < ActiveSupport::TestCase
@@ -109,12 +110,79 @@ module RailsPulse
       ENV["RAILS_PULSE_INSECURE_SESSION"] = original
     end
 
+    # Asset Tests
+    #
+    # The layout links either the gem-served bundle (/rails-pulse-assets/...)
+    # or, after assets:precompile, the digested copies under public/assets.
+    # Neither is served by the engine itself, so the rackup must serve both.
+
+    test "serves the gem-bundled dashboard stylesheet and scripts" do
+      %w[rails-pulse.css rails-pulse.js rails-pulse-icons.js].each do |asset|
+        response = lint_get("/rails-pulse-assets/#{RailsPulse::VERSION}/#{asset}")
+
+        assert_equal 200, response.status, "expected #{asset} to be served"
+        assert_operator response.body.bytesize, :>, 0
+      end
+    end
+
+    test "gem-bundled assets carry immutable cache headers" do
+      response = lint_get("/rails-pulse-assets/#{RailsPulse::VERSION}/rails-pulse.css")
+
+      assert_match(/immutable/, response.headers["cache-control"])
+    end
+
+    test "serves the digested assets installed by assets:precompile" do
+      destination = Rails.public_path.join("assets")
+      RailsPulse::PackagedAssets.install!(destination: destination)
+      digested_path = RailsPulse::PackagedAssets.url_path("rails-pulse.css")
+
+      assert_match(%r{\A/assets/rails-pulse-[a-f0-9]{64}\.css\z}, digested_path)
+
+      response = lint_get(digested_path)
+
+      assert_equal 200, response.status
+      assert_match(/immutable/, response.headers["cache-control"])
+    ensure
+      RailsPulse::PackagedAssets.uninstall!(destination: destination)
+    end
+
+    test "unknown asset paths fall through to the dashboard rather than the static server" do
+      response = lint_get("/assets/does-not-exist.css")
+
+      assert_not_equal 200, response.status
+    end
+
+    # Rack Compliance Tests
+    #
+    # rackup wraps the app in Rack::Lint in its development environment, so a
+    # non-compliant response (e.g. a mixed-case header name) is a 500 there.
+
+    test "dashboard and health responses pass Rack::Lint" do
+      assert_nothing_raised do
+        lint_get("/health")
+        lint_get("/")
+      end
+    end
+
     # Server Configuration Tests
 
-    test "server raises when SECRET_KEY_BASE is not set" do
+    test "falls back to the host app's secret_key_base when SECRET_KEY_BASE is not set" do
       ENV.delete("SECRET_KEY_BASE")
 
-      assert_raises(RuntimeError) { build_server_app }
+      app = build_server_app
+
+      assert_not_nil Rack::MockRequest.new(app).get("/").headers["Set-Cookie"]
+    end
+
+    test "server raises when neither SECRET_KEY_BASE nor a Rails secret_key_base is available" do
+      ENV.delete("SECRET_KEY_BASE")
+      Rails.application.stubs(:secret_key_base).returns(nil)
+
+      error = assert_raises(RuntimeError) { build_server_app }
+
+      assert_match(/SECRET_KEY_BASE/, error.message)
+    ensure
+      Rails.application.unstub(:secret_key_base)
     end
 
     private
@@ -133,6 +201,11 @@ module RailsPulse
 
     def get(path)
       Rack::MockRequest.new(@app).get(path)
+    end
+
+    # Rack::Lint raises on any spec violation in the request env or response.
+    def lint_get(path)
+      Rack::MockRequest.new(Rack::Lint.new(@app)).get(path)
     end
   end
 end


### PR DESCRIPTION
mise ~/.config/mise/config.toml tools: gh@2.99.0
## Summary

Fixes four defects that together made the standalone dashboard server (`rails_pulse_server` / `lib/rails_pulse_server.ru`) unusable out of the box. Found while deploying 0.4.0.pre.2's standalone mode on Fly.io; each was reproduced locally against the dummy app.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- **Serve dashboard assets from the rackup.** `rails_pulse_server.ru` calls `RailsPulse::Engine.call(env)` directly, bypassing the host middleware stack — which is where `RailsPulse::Middleware::AssetServer` (the `/rails-pulse-assets/<version>/...` fallback) and `ActionDispatch::Static` (the digested `/assets/...` copies `assets:precompile` installs via `PackagedAssets`) live. `RouteHelper#asset_path` emits one of those two URL shapes, and neither was served, so every standalone page rendered unstyled with 404s in the console. The rackup now mounts `AssetServer` for the first and `Rack::Static` (rooted at `Rails.public_path`) for the second.
- **Lowercase asset header names.** `Engine.asset_headers` and `AssetServer#cache_headers` used `Cache-Control`, `Vary`, `Expires`, `Pragma`. Rack 3 requires lowercase, and `Rack::Lint` rejects mixed case — which turned every asset request into a 500 under `rackup`'s default environment (see next point). Existing `AssetServerTest` assertions updated to match.
- **Pass the environment through to `rackup`.** `rackup` defaults to its own `development` environment regardless of `RAILS_ENV`, inserting `Rack::Lint` and `Rack::ShowExceptions` in production. `exe/rails_pulse_server` now passes `-E` from `RACK_ENV`, then `RAILS_ENV`, unless one is given explicitly.
- **Fall back to `Rails.application.secret_key_base`.** The rackup required a literal `SECRET_KEY_BASE` env var, which hosts on encrypted credentials don't have — even though `config/environment.rb` was already loaded. It still refuses to boot when neither is available.
- `docs/deployment-modes.md` and `CHANGELOG.md` updated accordingly.

### Test Results

- [x] All existing tests pass (`DB=sqlite3 rake test`, including `test_migrations`)
- [x] New tests added for new functionality — `standalone_server_test.rb` now requests both asset URL shapes, asserts cache headers, runs the dashboard and health responses through `Rack::Lint`, and covers both secret sources
- [x] Manual testing completed — deployed to a Fly.io app against a real 0.4 database; all three asset URLs return 200 and the dashboard renders
- [ ] Tested across multiple databases (SQLite, PostgreSQL, MySQL) — SQLite locally; nothing here is adapter-specific
- [ ] Tested across multiple Rails versions (7.2, 8.0, 8.1) — 8.1 locally

## Breaking Changes

- [x] No breaking changes

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Comments added for complex logic
- [x] Documentation updated (if applicable)
- [x] No new warnings or errors introduced
- [x] Tests added/updated and passing
- [x] Changes work with all supported databases
- [x] Changes work with all supported Rails versions
- [x] Asset changes compiled and included (if applicable) — no asset rebuild needed

## Additional Notes

`exe/rails_pulse_server` has no unit test; it `exec`s `rackup`, so the argument handling is a few lines reviewed by eye.

Two related follow-ups are deliberately **not** in this PR and come next, stacked on this branch: nav links generated from the host's mount path (they 404 when the dashboard is served at `/`), and host session-based `authentication_method` hooks that cannot work in a separate process.
