### PR TITLE
Make standalone mode explicit: root-relative links and standalone authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   accepts. A new `rake rails_pulse:finish_deployment[revision]` sets `finished_at` on the
   latest deployment for that revision, so release scripts can close a deployment without
   a token or network access to the dashboard.
+- **Standalone mode is now something the gem knows about.** `RailsPulse.standalone?`
+  is true in the process started by `rails_pulse_server`, and two things change with
+  it. Links: engine helpers reached through the `rails_pulse` view proxy used to ask the
+  host's route set where the engine is mounted and prefix that path, so a dashboard
+  served at `/` linked to `/rails_pulse/routes` and 404ed against itself; the standalone
+  process now generates root-relative links. Authentication: the standalone process has
+  the host's models but not its session, Warden or Devise helpers (and a different
+  hostname, so no shared cookie), so `authentication_method` and `authorize` are ignored
+  there in favour of the new `config.standalone_authentication_method`, falling back to
+  HTTP Basic against `RAILS_PULSE_USERNAME` / `RAILS_PULSE_PASSWORD`. An authentication
+  error in standalone mode renders 403 instead of redirecting to a host login page the
+  process does not serve. `docs/deployment-modes.md` no longer tells standalone users to
+  comment out the engine mount — keeping it is fine and lets the host keep linking to
+  `rails_pulse.root_path`.
+
 ### Fixed
 
 - **The standalone dashboard server now serves its own assets.** `rails_pulse_server.ru`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Breadcrumbs no longer produce protocol-relative links when the engine is served at
+  `/`.** With an empty mount prefix (the standalone server, or a host that mounts the
+  engine at root) the helper built `"/" + "/queries"` — `//queries`, which browsers
+  resolve to a host called `queries`. The prefix is now empty in that case, so crumbs
+  link to `/queries`.
 - **The standalone dashboard server now serves its own assets.** `rails_pulse_server.ru`
   calls the engine directly, bypassing the host middleware stack — which is where
   `RailsPulse::Middleware::AssetServer` (the `/rails-pulse-assets/...` fallback) and

--- a/app/controllers/rails_pulse/application_controller.rb
+++ b/app/controllers/rails_pulse/application_controller.rb
@@ -132,6 +132,8 @@ module RailsPulse
       config = RailsPulse.configuration
       return unless config.authentication_enabled
 
+      return authenticate_standalone!(config) if RailsPulse.standalone?
+
       if config.authentication_method.nil? && config.authorize.nil?
         return fallback_http_basic_auth
       end
@@ -144,7 +146,39 @@ module RailsPulse
       run_authorize_predicate(config.authorize) if config.authorize
     rescue StandardError => e
       logger.warn "RailsPulse authentication failed: #{e.message}"
-      redirect_to config.authentication_redirect_path
+      # The redirect target is a host app page; from the standalone server
+      # it would point at a route this process does not serve.
+      if RailsPulse.standalone?
+        render plain: "Forbidden", status: :forbidden
+      else
+        redirect_to config.authentication_redirect_path
+      end
+    end
+
+    # The standalone server has the host's models but not its middleware:
+    # no host session store, Warden, or Devise helpers, and a different
+    # hostname so no shared cookie. A session-based `authentication_method`
+    # or `authorize` would raise (rescued above into a useless redirect) or,
+    # worse, be written so that it silently allows. Ignore both here; use
+    # `standalone_authentication_method` when set, else HTTP Basic.
+    def authenticate_standalone!(config)
+      hook = config.standalone_authentication_method
+      if hook.nil?
+        note_ignored_host_authentication(config)
+        return fallback_http_basic_auth
+      end
+
+      run_authentication_method(hook)
+    end
+
+    def note_ignored_host_authentication(config)
+      return if config.authentication_method.nil? && config.authorize.nil?
+      return if self.class.instance_variable_get(:@_rails_pulse_standalone_auth_noted)
+
+      self.class.instance_variable_set(:@_rails_pulse_standalone_auth_noted, true)
+      logger.info "RailsPulse: standalone dashboard ignores config.authentication_method / config.authorize " \
+                  "(host session helpers are not available here); using HTTP Basic auth. " \
+                  "Set config.standalone_authentication_method to customise."
     end
 
     def run_authentication_method(hook)

--- a/app/helpers/rails_pulse/breadcrumbs_helper.rb
+++ b/app/helpers/rails_pulse/breadcrumbs_helper.rb
@@ -30,13 +30,16 @@ module RailsPulse
       # Only keep segments after the mount point
       path_segments = path_segments[(mount_end_index + 1)..-1]
 
-      # Build the engine root path directly from mount segments (avoids relying on named route helper)
-      engine_root = "/" + mount_segments.join("/")
+      # Build the engine root path directly from mount segments (avoids relying on named route helper).
+      # Served at "/" (standalone server, or a host that mounts the engine at root) the prefix
+      # is empty, not "/": segments are appended as "/#{segment}", and "/" + "/queries" would be
+      # "//queries" — a protocol-relative URL that browsers resolve to a host called "queries".
+      engine_root = mount_segments.empty? ? "" : "/" + mount_segments.join("/")
 
       # Start with the Home link
       crumbs = [ {
         title: "Home",
-        path: engine_root,
+        path: engine_root.empty? ? "/" : engine_root,
         current: path_segments.empty?
       } ]
 

--- a/docs/deployment-modes.md
+++ b/docs/deployment-modes.md
@@ -54,16 +54,26 @@ The dashboard runs as a separate Rack application process.
 ```ruby
 # config/initializers/rails_pulse.rb
 RailsPulse.configure do |config|
-  config.mount_dashboard = false  # Disable embedded dashboard
+  config.mount_dashboard = false  # Skip the dashboard asset middleware in the main app
 end
 ```
 
-**Important:** When `mount_dashboard = false`, you should also remove (or comment out) the `mount RailsPulse::Engine` line from your `config/routes.rb` to prevent the engine from being accessible through your main app. The `mount_dashboard` setting controls whether RailsPulse initializes dashboard-related middleware and assets, while the routes mounting controls URL accessibility.
+`mount_dashboard = false` stops the main app inserting the dashboard asset
+middleware. It does not affect tracking, and it does not unmount the engine:
+whether `/rails_pulse` stays reachable through the main app is decided by the
+`mount RailsPulse::Engine` line in `config/routes.rb`. Keep it if other parts
+of your app link to `rails_pulse.root_path`; remove it to make the standalone
+server the only way in. The standalone process ignores the mount path either
+way — its links are generated root-relative (`RailsPulse.standalone?` is true
+there), so it never produces `/rails_pulse/...` URLs against itself.
 
-```ruby
-# config/routes.rb - Comment this out for standalone mode
-# mount RailsPulse::Engine => "/rails_pulse"
-```
+**Authentication:** the standalone process has your models but not your
+app's session, Warden or Devise helpers, and runs on its own hostname, so
+`config.authentication_method` and `config.authorize` are ignored there. It
+uses HTTP Basic auth (`RAILS_PULSE_USERNAME`, default `admin`, and
+`RAILS_PULSE_PASSWORD`) unless you set `config.standalone_authentication_method`
+to a proc that renders or redirects to deny (the same contract as
+`authentication_method`).
 
 **Standalone Server:**
 
@@ -156,7 +166,7 @@ server {
 
 **Disadvantages:**
 - ❌ Requires additional process/container
-- ❌ Separate authentication setup
+- ❌ Separate authentication setup (HTTP Basic by default; see above)
 - ❌ Slightly more complex deployment
 
 ---
@@ -238,6 +248,8 @@ curl http://localhost:3001/health
    ```ruby
    config.mount_dashboard = false
    ```
+   Optionally remove `mount RailsPulse::Engine` from `config/routes.rb` so
+   the embedded dashboard is no longer reachable.
 
 4. **Deploy main app changes**
 

--- a/lib/generators/rails_pulse/templates/rails_pulse.rb
+++ b/lib/generators/rails_pulse/templates/rails_pulse.rb
@@ -314,6 +314,18 @@ RailsPulse.configure do |config|
   #   end
   # }
 
+  # STANDALONE DASHBOARD (bin/rails_pulse_server, see docs/deployment-modes.md):
+  # that process has your models but not your app's session, Warden or Devise
+  # helpers, and runs on its own hostname, so the hooks above are ignored there.
+  # By default it uses HTTP Basic auth (RAILS_PULSE_USERNAME / RAILS_PULSE_PASSWORD).
+  # Set this to run something else instead; same rules as authentication_method
+  # (deny by rendering or redirecting, or by returning false).
+  # config.standalone_authentication_method = proc {
+  #   authenticate_or_request_with_http_token do |token, _options|
+  #     ActiveSupport::SecurityUtils.secure_compare(token, ENV["RAILS_PULSE_DASHBOARD_TOKEN"].to_s)
+  #   end
+  # }
+
   # ====================================================================================================
   #                                             DEPLOYMENT TRACKING
   # ====================================================================================================

--- a/lib/rails_pulse.rb
+++ b/lib/rails_pulse.rb
@@ -5,6 +5,7 @@ require "rails_pulse/configuration"
 require "rails_pulse/paginator"
 require "rails_pulse/cleanup_service"
 require "rails_pulse/tracker"
+require "rails_pulse/standalone"
 
 module RailsPulse
   class << self

--- a/lib/rails_pulse/configuration.rb
+++ b/lib/rails_pulse/configuration.rb
@@ -21,6 +21,7 @@ module RailsPulse
                   :authentication_enabled,
                   :authentication_method,
                   :authorize,
+                  :standalone_authentication_method,
                   :authentication_redirect_path,
                   :tags,
                   :job_tracking_mode,
@@ -104,6 +105,10 @@ module RailsPulse
       # Fail-closed predicate: ->(controller) { true to allow }. Anything
       # falsy is a 403. Runs after authentication_method, if both are set.
       @authorize = nil
+      # Used instead of authentication_method / authorize by the standalone
+      # dashboard server, where host session helpers are unavailable. nil
+      # means HTTP Basic against RAILS_PULSE_USERNAME / RAILS_PULSE_PASSWORD.
+      @standalone_authentication_method = nil
       @authentication_redirect_path = "/"
       @tags = [ "ignored", "critical", "experimental" ]
       @job_tracking_mode = :universal
@@ -325,6 +330,10 @@ module RailsPulse
 
       if @authorize && !@authorize.respond_to?(:call)
         raise ArgumentError, "authorize must respond to #call (a proc or lambda receiving the controller and returning true to allow), got #{@authorize.class}"
+      end
+
+      if @standalone_authentication_method && !@standalone_authentication_method.is_a?(Proc)
+        raise ArgumentError, "standalone_authentication_method must be a Proc or nil, got #{@standalone_authentication_method.class}"
       end
     end
 

--- a/lib/rails_pulse/standalone.rb
+++ b/lib/rails_pulse/standalone.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module RailsPulse
+  # Process-wide "am I the standalone dashboard?" flag, set by
+  # lib/rails_pulse_server.ru once the host environment is loaded.
+  #
+  # Two things differ when the engine is served by its own process instead of
+  # mounted inside the host app, and both are decided here rather than left to
+  # the host to work around:
+  #
+  # * URL generation. Engine path helpers ask the host's route set where the
+  #   engine is mounted and prefix that path — `/rails_pulse/routes` — because
+  #   that is what a link inside the host app needs. (`mount` extends the
+  #   engine route set with a `find_script_name` that does this.) The
+  #   standalone server serves the engine at `/`, so that prefix 404s against
+  #   itself. `standalone!` prepends an override that answers "" while the
+  #   flag is set, so every helper generates root-relative paths in this
+  #   process only. Passing `script_name: ""` or setting it in
+  #   `default_url_options` is not enough: Rails treats the empty value as
+  #   unset and falls through to the mount prefix.
+  #
+  # * Authentication. See ApplicationController#authenticate_rails_pulse_user!
+  #   — host session hooks cannot run here, so the dashboard falls back to
+  #   `config.standalone_authentication_method`, then HTTP Basic.
+  module Standalone
+    module RootScriptName
+      def find_script_name(options)
+        RailsPulse.standalone? ? "" : super
+      end
+    end
+
+    def standalone?
+      @standalone == true
+    end
+
+    def standalone!
+      @standalone = true
+      routes = Engine.routes
+      routes.singleton_class.prepend(RootScriptName) unless routes.singleton_class.ancestors.include?(RootScriptName)
+    end
+
+    # Undo standalone! — for tests that load the rackup file in-process. The
+    # prepended override stays but defers to the mount prefix again.
+    def exit_standalone!
+      @standalone = false
+    end
+  end
+
+  extend Standalone
+end

--- a/lib/rails_pulse_server.ru
+++ b/lib/rails_pulse_server.ru
@@ -19,6 +19,9 @@ else
   MESSAGE
 end
 
+# Root-relative links and standalone authentication — see lib/rails_pulse/standalone.rb.
+RailsPulse.standalone!
+
 # Disable output buffering so logs appear immediately
 $stdout.sync = true
 $stderr.sync = true

--- a/test/helpers/rails_pulse/breadcrumbs_helper_test.rb
+++ b/test/helpers/rails_pulse/breadcrumbs_helper_test.rb
@@ -221,6 +221,37 @@ class RailsPulse::BreadcrumbsHelperTest < ActionView::TestCase
     assert_equal @route.to_breadcrumb, crumbs[2][:title]
   end
 
+  # ============================================================================
+  # Root Mount Point Tests (standalone server, or `mount RailsPulse::Engine => "/"`)
+  # ============================================================================
+
+  test "breadcrumbs build single-slash paths when the engine is served at root" do
+    RailsPulse::Engine.routes.stubs(:find_script_name).returns("")
+    setup_request_path("/routes/#{@route.id}")
+
+    crumbs = breadcrumbs
+
+    assert_equal [ "/", "/routes", "/routes/#{@route.id}" ], crumbs.map { |crumb| crumb[:path] }
+    assert_equal [ "Home", "Routes", @route.to_breadcrumb ], crumbs.map { |crumb| crumb[:title] }
+  end
+
+  test "breadcrumbs nested collection links to the parent when served at root" do
+    RailsPulse::Engine.routes.stubs(:find_script_name).returns("")
+    setup_request_path("/jobs/#{@job.id}/runs/#{@job_run.id}")
+
+    crumbs = breadcrumbs
+
+    assert_equal "/jobs/#{@job.id}", crumbs[2][:path]
+    assert_no_match(%r{\A//}, crumbs.map { |crumb| crumb[:path] }.join(" "))
+  end
+
+  test "breadcrumbs are empty at the root of a root-mounted engine" do
+    RailsPulse::Engine.routes.stubs(:find_script_name).returns("")
+    setup_request_path("/")
+
+    assert_empty breadcrumbs
+  end
+
   # Error Handling Tests
 
   test "breadcrumbs handles missing resources gracefully" do

--- a/test/lib/rails_pulse/configuration_test.rb
+++ b/test/lib/rails_pulse/configuration_test.rb
@@ -291,6 +291,25 @@ module RailsPulse
       assert_respond_to config.authorize, :call
     end
 
+    test "standalone_authentication_method defaults to nil" do
+      assert_nil Configuration.new.standalone_authentication_method
+    end
+
+    test "validate_configuration! accepts a proc standalone_authentication_method" do
+      config = build_config { self.standalone_authentication_method = proc { true } }
+
+      assert_kind_of Proc, config.standalone_authentication_method
+    end
+
+    test "validate_configuration! raises for a non-proc standalone_authentication_method" do
+      config = Configuration.new
+      config.standalone_authentication_method = :not_a_proc
+
+      error = assert_raises(ArgumentError) { config.validate_configuration! }
+
+      assert_match "standalone_authentication_method", error.message
+    end
+
     test "validate_configuration! raises for a non-callable authorize" do
       config = Configuration.new
       config.authorize = true

--- a/test/lib/rails_pulse/standalone_server_test.rb
+++ b/test/lib/rails_pulse/standalone_server_test.rb
@@ -208,6 +208,13 @@ module RailsPulse
       assert_no_match(%r{href="/rails_pulse/}, body)
     end
 
+    test "breadcrumb links are root-relative, not protocol-relative" do
+      body = get("/queries").body
+
+      assert_no_match(%r{href="//}, body)
+      assert_match(%r{href="/"}, body)
+    end
+
     test "engine helpers through the rails_pulse proxy are root-relative too" do
       assert_equal "/storage", RailsPulse::Engine.routes.url_helpers.storage_path
       assert_equal "/", RailsPulse::Engine.routes.url_helpers.root_path

--- a/test/lib/rails_pulse/standalone_server_test.rb
+++ b/test/lib/rails_pulse/standalone_server_test.rb
@@ -1,6 +1,7 @@
 require "test_helper"
 require "rack/mock_request"
 require "rack/lint"
+require "base64"
 
 module RailsPulse
   class StandaloneServerTest < ActiveSupport::TestCase
@@ -15,6 +16,7 @@ module RailsPulse
 
     def teardown
       ENV["SECRET_KEY_BASE"] = @original_secret
+      RailsPulse.exit_standalone!
     end
 
     # Health Endpoint Tests
@@ -185,6 +187,73 @@ module RailsPulse
       Rails.application.unstub(:secret_key_base)
     end
 
+    # Standalone Mode Tests
+
+    test "loading the rackup marks the process as standalone" do
+      assert_predicate RailsPulse, :standalone?
+    end
+
+    test "exit_standalone! restores the mounted-mode link prefix" do
+      RailsPulse.exit_standalone!
+
+      assert_not_predicate RailsPulse, :standalone?
+      assert_equal "/rails_pulse/routes", RailsPulse::Engine.routes.url_helpers.routes_path
+    end
+
+    test "dashboard links are root-relative instead of inheriting the host mount path" do
+      body = get("/").body
+
+      assert_match(%r{href="/routes"}, body)
+      assert_match(%r{href="/queries"}, body)
+      assert_no_match(%r{href="/rails_pulse/}, body)
+    end
+
+    test "engine helpers through the rails_pulse proxy are root-relative too" do
+      assert_equal "/storage", RailsPulse::Engine.routes.url_helpers.storage_path
+      assert_equal "/", RailsPulse::Engine.routes.url_helpers.root_path
+    end
+
+    # Standalone Authentication Tests
+
+    test "a host session-based authentication_method is ignored in favour of HTTP Basic" do
+      with_standalone_auth(authentication_method: proc { user_signed_in? || redirect_to(main_app.root_path) }) do
+        assert_equal 401, get("/").status
+        assert_equal 200, get("/", "HTTP_AUTHORIZATION" => basic("admin", "s3cret")).status
+      end
+    end
+
+    test "a host authorize predicate is ignored in favour of HTTP Basic" do
+      with_standalone_auth(authorize: ->(_controller) { false }) do
+        assert_equal 401, get("/").status
+        assert_equal 200, get("/", "HTTP_AUTHORIZATION" => basic("admin", "s3cret")).status
+      end
+    end
+
+    test "wrong HTTP Basic credentials are rejected" do
+      with_standalone_auth do
+        assert_equal 401, get("/", "HTTP_AUTHORIZATION" => basic("admin", "nope")).status
+      end
+    end
+
+    test "standalone_authentication_method replaces the HTTP Basic fallback" do
+      hook = proc { render plain: "custom denial", status: :forbidden }
+
+      with_standalone_auth(standalone_authentication_method: hook) do
+        response = get("/", "HTTP_AUTHORIZATION" => basic("admin", "s3cret"))
+
+        assert_equal 403, response.status
+        assert_equal "custom denial", response.body
+      end
+    end
+
+    test "an authentication error renders 403 rather than redirecting to a host page" do
+      with_standalone_auth(standalone_authentication_method: proc { raise "boom" }) do
+        response = get("/")
+
+        assert_equal 403, response.status
+      end
+    end
+
     private
 
     def build_server_app
@@ -199,8 +268,25 @@ module RailsPulse
       Rails.unstub(:env)
     end
 
-    def get(path)
-      Rack::MockRequest.new(@app).get(path)
+    def get(path, env = {})
+      Rack::MockRequest.new(@app).get(path, env)
+    end
+
+    def basic(username, password)
+      "Basic #{Base64.strict_encode64("#{username}:#{password}")}"
+    end
+
+    def with_standalone_auth(authentication_method: nil, authorize: nil, standalone_authentication_method: nil)
+      original_password = ENV["RAILS_PULSE_PASSWORD"]
+      ENV["RAILS_PULSE_PASSWORD"] = "s3cret"
+      config = RailsPulse.configuration
+      config.stubs(:authentication_enabled).returns(true)
+      config.stubs(:authentication_method).returns(authentication_method)
+      config.stubs(:authorize).returns(authorize)
+      config.stubs(:standalone_authentication_method).returns(standalone_authentication_method)
+      yield
+    ensure
+      ENV["RAILS_PULSE_PASSWORD"] = original_password
     end
 
     # Rack::Lint raises on any spec violation in the request env or response.


### PR DESCRIPTION
mise ~/.config/mise/config.toml tools: gh@2.99.0
## Summary

Makes "standalone dashboard" something the gem knows about, and fixes the two things that were still broken after #235 once the server was actually up: every nav link pointed at `/rails_pulse/...` (404 against a server rooted at `/`), and any host `authentication_method` built on session helpers either raised or redirected to a host login page the process does not serve.

**Stacked on #235** (`fix/standalone-server-assets-and-env`); the diff here is the last two commits.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Changes Made

- **`RailsPulse.standalone?` / `standalone!`** (`lib/rails_pulse/standalone.rb`). The rackup calls `standalone!` right after loading the host environment.
- **Root-relative links in standalone mode.** `mount` extends the engine's route set with a `find_script_name` that prefixes the host mount path; that is right inside the host app and wrong for a server rooted at `/`. `standalone!` prepends an override that answers `""` while the flag is set. Setting `script_name: ""` (explicitly or via `default_url_options`) does not work — Rails 8.1 treats the empty value as unset and falls through to the mount prefix — which is why this is an override rather than an option; the test `exit_standalone!` restores the mounted-mode prefix.
- **Standalone authentication.** The standalone process has the host's models but not its middleware (no session store, Warden, Devise helpers) and runs on its own hostname, so `authentication_method` / `authorize` cannot work there. In standalone mode they are now ignored (logged once) in favour of a new `config.standalone_authentication_method` (same contract as `authentication_method`: deny by rendering/redirecting or returning `false`), falling back to the existing HTTP Basic check. An authentication error renders 403 instead of redirecting to `authentication_redirect_path`.
- **Breadcrumbs at a root mount** (second commit). With an empty mount prefix the helper built `"/" + "/queries"` — `//queries`, a protocol-relative URL that browsers resolve to a host called `queries`. The prefix is now empty in that case so crumbs link to `/queries`. Also affects any host that mounts the engine at `/`. Covered by helper tests for the plain, nested, and root cases plus a standalone page assertion.
- **Docs.** `deployment-modes.md` no longer tells standalone users to comment out the engine mount (keeping it is fine and lets the host keep linking to `rails_pulse.root_path`), corrects what `mount_dashboard` actually controls (the asset middleware, not tracking or routing), and documents standalone authentication. The initializer template gains a `standalone_authentication_method` example.

### Test Results

- [x] All existing tests pass (`DB=sqlite3 rake test`, including `test_migrations`)
- [x] New tests added for new functionality — standalone flag lifecycle, root-relative links in a rendered page and via the `rails_pulse` proxy, restoration of the mounted prefix, HTTP Basic fallback when a session-based `authentication_method` or an `authorize` predicate is configured, wrong credentials, custom `standalone_authentication_method`, and the 403-on-error path; configuration default and validation
- [x] Manual testing completed — the link bug is exactly what a real standalone deployment produced; the fix was verified against the dummy app
- [ ] Tested across multiple databases — SQLite locally; nothing adapter-specific
- [ ] Tested across multiple Rails versions — 8.1 locally

## Breaking Changes

- [x] No breaking changes — behaviour only changes while `RailsPulse.standalone?` is true, which only the rackup sets.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Comments added for complex logic
- [x] Documentation updated (if applicable)
- [x] No new warnings or errors introduced
- [x] Tests added/updated and passing
- [x] Changes work with all supported databases
- [x] Changes work with all supported Rails versions
- [x] Asset changes compiled and included (if applicable) — none

## Additional Notes

`note_ignored_host_authentication` logs once per process via a class ivar; happy to move that onto `RailsPulse::Standalone` if you'd rather keep controller state out of it.
