### PR TITLE
Add rails_pulse:status task reporting schema, migration, backfill and initializer state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   process does not serve. `docs/deployment-modes.md` no longer tells standalone users to
   comment out the engine mount — keeping it is fine and lets the host keep linking to
   `rails_pulse.root_path`.
+- **`rails rails_pulse:status`.** One shell command that says where an install stands:
+  whether the schema is current for the running gem (via `RailsPulse::SchemaCheck`), gem
+  migrations not yet copied into the app, migration files present but not run, whether
+  `rails_pulse:migrate_routes` and the unrecognised-path index are done, settings this
+  version added that the initializer does not mention, the tracking and authentication
+  configuration, and when summaries last ran. Everything that needs action is repeated in
+  a closing list and the task exits 1, so a release script can stop before serving
+  traffic. `RailsPulse::Installers::ConfigUpdater.missing` is the read-only counterpart
+  of `update` that backs the initializer check.
 - **Schema drift guard.** New gem code running against tables that have not been
   migrated for it — a deploy that shipped the gem before `db:migrate`, or a rolling
   restart that left old and new processes side by side — used to log "Failed to

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Restart all processes after migrate. This release changes how routes are stored 
 
 The upgrade generator appends new settings to `config/initializers/rails_pulse.rb` without rewriting what you already set. Review with `git diff` and keep or discard hunks.
 
+To see where an install stands at any point — schema, unrun migration files, route backfill, initializer — run `rails rails_pulse:status`. It exits 1 when something needs action, so it can gate a deploy.
+
 Exception tracking is **off** for existing installs. The generator inserts `config.track_exceptions = false`; set it to `true` after migrating to opt in:
 
 ```ruby

--- a/docs/database_setup.md
+++ b/docs/database_setup.md
@@ -104,6 +104,14 @@ The generator automatically handles both upgrade paths:
 - If new migrations exist in the gem → copies them to your app
 - If no new migrations but missing columns → generates a migration for you
 
+### Checking where an install stands
+
+```bash
+rails rails_pulse:status
+```
+
+Prints, for the Pulse connection: whether the schema is current for the running gem, gem migrations not yet copied into the app, migration files present but not run, whether the route backfill and unrecognised-path index are done, settings this version added that the initializer does not mention, the tracking/authentication configuration, and when summaries last ran. Anything that needs action is repeated at the end, and the task exits 1 in that case so a release script can stop on it.
+
 ### If the new gem is deployed before the migrations run
 
 Rails Pulse checks the live tables once per process, the first time it needs to

--- a/lib/rails_pulse/engine.rb
+++ b/lib/rails_pulse/engine.rb
@@ -66,6 +66,7 @@ module RailsPulse
   # Task runners
   module Tasks
     autoload :CleanupTaskRunner, File.expand_path("tasks/cleanup_task_runner", __dir__)
+    autoload :StatusReporter, File.expand_path("tasks/status_reporter", __dir__)
   end
 
   class Engine < ::Rails::Engine

--- a/lib/rails_pulse/installers/config_updater.rb
+++ b/lib/rails_pulse/installers/config_updater.rb
@@ -27,6 +27,11 @@ module RailsPulse
         new(destination: destination, source: source, output: output).update
       end
 
+      # What `update` would add, without writing anything.
+      def self.missing(destination:, source: nil)
+        new(destination: destination, source: source).missing
+      end
+
       def self.template_path
         File.expand_path("../../../../lib/generators/rails_pulse/templates/rails_pulse.rb", __FILE__)
       end
@@ -35,6 +40,18 @@ module RailsPulse
         @destination = destination
         @source = source || self.class.template_path
         @output = output
+      end
+
+      # { keys: [setting keys absent from the host file], hash_keys: [names of
+      # entries absent from a hash the host does set] }. Empty arrays when the
+      # host mentions everything; both empty when the file does not exist.
+      def missing
+        return { keys: [], hash_keys: [] } unless File.exist?(destination)
+
+        host = File.read(destination)
+        missing_keys = template_settings.map { |setting| setting[:key] } - mentioned_keys(host)
+        hash_keys = missing_hash_entries(host, missing_keys)
+        { keys: missing_keys, hash_keys: hash_keys.map { |entry| entry[:name] } }
       end
 
       def update

--- a/lib/rails_pulse/tasks/status_reporter.rb
+++ b/lib/rails_pulse/tasks/status_reporter.rb
@@ -1,0 +1,217 @@
+# frozen_string_literal: true
+
+module RailsPulse
+  module Tasks
+    # `rails rails_pulse:status` — where does this install stand?
+    #
+    # Answers, from the shell and without opening the dashboard, the questions
+    # an upgrade tends to leave hanging: is the schema current for this gem,
+    # are there migration files that have not been run, has the route backfill
+    # been done, does the initializer mention the settings this version added.
+    # Anything that needs action is repeated in a closing "Action needed"
+    # list, and `report` returns false in that case so release scripts can
+    # stop on it.
+    class StatusReporter
+      attr_reader :output, :config
+
+      def self.report(output: $stdout)
+        new(output: output).report
+      end
+
+      def initialize(output: $stdout)
+        @output = output
+        @config = RailsPulse.configuration
+        @actions = []
+      end
+
+      # Returns true when nothing needs attention.
+      def report
+        output.puts "Rails Pulse #{RailsPulse::VERSION}"
+        output.puts
+
+        print_database
+        print_schema
+        print_migrations
+        print_route_backfill
+        print_initializer
+        print_tracking
+        print_summaries
+        print_actions
+
+        @actions.empty?
+      end
+
+      private
+
+      def action(text)
+        @actions << text
+      end
+
+      # -- sections -----------------------------------------------------------
+
+      def print_database
+        connection = RailsPulse::ApplicationRecord.connection
+        name = RailsPulse::ApplicationRecord.connection_db_config.name
+        separate = config.connects_to.present?
+        output.puts "Database:   #{connection.adapter_name} (#{name}#{separate ? ", separate Pulse database" : ""})"
+      rescue StandardError => e
+        output.puts "Database:   unavailable (#{e.class}: #{e.message})"
+        action "Database connection failed; nothing below could be checked."
+      end
+
+      def print_schema
+        RailsPulse::SchemaCheck.reset!
+        missing = RailsPulse::SchemaCheck.missing
+
+        if missing.empty?
+          output.puts "Schema:     up to date for #{RailsPulse::VERSION}"
+          return
+        end
+
+        output.puts "Schema:     BEHIND this gem version"
+        missing.each do |table, columns|
+          output.puts(columns == [ :table ] ? "              #{table}: table missing" : "              #{table}: missing #{columns.join(', ')}")
+        end
+        action "Schema is behind the gem. Run: #{upgrade_commands.join(' && ')}"
+      end
+
+      def print_migrations
+        not_copied = gem_migrations_not_in_host
+        pending = pending_migrations
+
+        if not_copied.empty? && pending.empty?
+          output.puts "Migrations: none pending"
+          return
+        end
+
+        if not_copied.any?
+          output.puts "Migrations: #{not_copied.size} gem migration(s) not yet copied into this app:"
+          not_copied.each { |name| output.puts "              #{name}" }
+          action "Copy this version's migrations: rails generate rails_pulse:upgrade"
+        end
+
+        if pending.any?
+          output.puts "Migrations: #{pending.size} migration file(s) present but not run:"
+          pending.each { |name| output.puts "              #{name}" }
+          action "Run pending migrations: #{migrate_command}"
+        end
+      end
+
+      def print_route_backfill
+        unless RailsPulse::SchemaCheck.current?
+          output.puts "Routes:     (skipped — schema is behind)"
+          return
+        end
+
+        backfill = RailsPulse::Route.needs_action_backfill?
+        index = RailsPulse::RouteIndexes.exists?(RailsPulse::ApplicationRecord.connection)
+
+        if !backfill && index
+          output.puts "Routes:     actions backfilled, unrecognised-path index present"
+          return
+        end
+
+        output.puts "Routes:     #{backfill ? 'actions NOT backfilled' : 'actions backfilled'}, " \
+                    "unrecognised-path index #{index ? 'present' : 'MISSING'}"
+        action "Backfill route actions and create the unrecognised-path index: rails rails_pulse:migrate_routes"
+      rescue StandardError => e
+        output.puts "Routes:     could not check (#{e.class}: #{e.message})"
+      end
+
+      def print_initializer
+        path = Rails.root.join("config", "initializers", "rails_pulse.rb")
+        unless path.exist?
+          output.puts "Initializer: config/initializers/rails_pulse.rb not found"
+          action "Create the initializer: rails generate rails_pulse:install"
+          return
+        end
+
+        missing = RailsPulse::Installers::ConfigUpdater.missing(destination: path.to_s)
+        keys = missing[:keys] + missing[:hash_keys]
+        if keys.empty?
+          output.puts "Initializer: mentions every setting this version knows"
+          return
+        end
+
+        output.puts "Initializer: #{keys.size} setting(s) from this version not mentioned: #{keys.join(', ')}"
+        action "Append the new settings to the initializer: rails generate rails_pulse:upgrade (review with git diff)"
+      end
+
+      def print_tracking
+        auth = if !config.authentication_enabled
+          "disabled"
+        elsif config.authentication_method || config.authorize
+          "custom hook"
+        else
+          "HTTP Basic (RAILS_PULSE_PASSWORD #{ENV["RAILS_PULSE_PASSWORD"].to_s.empty? ? 'NOT set' : 'set'})"
+        end
+
+        output.puts "Tracking:   enabled=#{config.enabled} requests=#{config.enabled} jobs=#{config.track_jobs} " \
+                    "exceptions=#{config.track_exceptions} async=#{config.async}"
+        output.puts "Dashboard:  mount_dashboard=#{config.mount_dashboard} authentication=#{auth}"
+      end
+
+      def print_summaries
+        last = RailsPulse::Summary.maximum(:updated_at)
+        if last.nil?
+          output.puts "Summaries:  none generated yet (schedule RailsPulse::SummaryJob hourly; backfill with rails rails_pulse:backfill_summaries)"
+        elsif last < 2.hours.ago
+          output.puts "Summaries:  last generated #{time_ago(last)} — stale (is RailsPulse::SummaryJob scheduled?)"
+        else
+          output.puts "Summaries:  last generated #{time_ago(last)}"
+        end
+      rescue StandardError => e
+        output.puts "Summaries:  could not check (#{e.class}: #{e.message})"
+      end
+
+      def print_actions
+        output.puts
+        if @actions.empty?
+          output.puts "OK — nothing to do."
+        else
+          output.puts "Action needed:"
+          @actions.each { |text| output.puts "  - #{text}" }
+        end
+      end
+
+      # -- helpers ------------------------------------------------------------
+
+      def gem_migrations_not_in_host
+        gem_dir = RailsPulse::Engine.root.join("db", "rails_pulse_migrate")
+        return [] unless gem_dir.directory?
+
+        host = %w[db/migrate db/rails_pulse_migrate].flat_map do |dir|
+          Dir.glob(Rails.root.join(dir, "*.rb").to_s).map { |f| File.basename(f) }
+        end
+        Dir.glob(gem_dir.join("*.rb").to_s).map { |f| File.basename(f) }.sort - host
+      end
+
+      # Migration files on disk whose version is not recorded on the Pulse
+      # connection. Names only; the versions are in the filenames.
+      def pending_migrations
+        context = RailsPulse::ApplicationRecord.connection_pool.migration_context
+        applied = context.get_all_versions
+        context.migrations.reject { |m| applied.include?(m.version) }.map { |m| File.basename(m.filename) }
+      rescue StandardError
+        []
+      end
+
+      def upgrade_commands
+        [ "rails generate rails_pulse:upgrade", migrate_command, "rails rails_pulse:migrate_routes" ]
+      end
+
+      def migrate_command
+        config.connects_to.present? ? "rails db:migrate:rails_pulse" : "rails db:migrate"
+      end
+
+      def time_ago(time)
+        seconds = (Time.current - time).to_i
+        return "#{seconds}s ago" if seconds < 60
+        return "#{seconds / 60}m ago" if seconds < 3600
+        return "#{seconds / 3600}h ago" if seconds < 86_400
+
+        "#{seconds / 86_400}d ago"
+      end
+    end
+  end
+end

--- a/lib/tasks/rails_pulse_tasks.rake
+++ b/lib/tasks/rails_pulse_tasks.rake
@@ -23,6 +23,11 @@ namespace :rails_pulse do
     RailsPulse::Stats::CleanupStatsReporter.report
   end
 
+  desc "Reports schema, migration, route backfill and initializer state for this install; exits 1 when something needs action."
+  task status: :environment do
+    exit 1 unless RailsPulse::Tasks::StatusReporter.report
+  end
+
   desc "Migrate existing routes: backfill controller actions, normalize paths, consolidate multi-verb routes."
   task migrate_routes: :environment do
     ca_results = RailsPulse::RouteControllerActionBackfiller.call

--- a/test/lib/rails_pulse/installers/config_updater_test.rb
+++ b/test/lib/rails_pulse/installers/config_updater_test.rb
@@ -15,6 +15,34 @@ module RailsPulse
         FileUtils.remove_entry(@dir)
       end
 
+      # Missing (read-only) Tests
+
+      test "missing reports what update would add without writing" do
+        write_template <<~RUBY
+          RailsPulse.configure do |config|
+            config.enabled = true
+            config.track_exceptions = true
+          end
+        RUBY
+        write_host <<~RUBY
+          RailsPulse.configure do |config|
+            config.enabled = true
+          end
+        RUBY
+        before = File.read(@destination)
+
+        missing = ConfigUpdater.missing(destination: @destination, source: @template)
+
+        assert_equal({ keys: %w[track_exceptions], hash_keys: [] }, missing)
+        assert_equal before, File.read(@destination)
+      end
+
+      test "missing is empty when the host file does not exist" do
+        write_template "RailsPulse.configure do |config|\n  config.enabled = true\nend\n"
+
+        assert_equal({ keys: [], hash_keys: [] }, ConfigUpdater.missing(destination: @destination, source: @template))
+      end
+
       # Insert Tests
 
       test "inserts missing settings without rewriting existing values" do

--- a/test/lib/rails_pulse/tasks/status_reporter_test.rb
+++ b/test/lib/rails_pulse/tasks/status_reporter_test.rb
@@ -1,0 +1,133 @@
+require "test_helper"
+
+class RailsPulse::Tasks::StatusReporterTest < ActiveSupport::TestCase
+  fixtures :rails_pulse_summaries
+
+  def setup
+    super
+    @output = StringIO.new
+    RailsPulse::SchemaCheck.reset!
+  end
+
+  def teardown
+    RailsPulse::SchemaCheck.reset!
+    super
+  end
+
+  # Structure Tests
+
+  test "reports every section against the dummy app" do
+    report
+
+    assert_match(/\ARails Pulse #{Regexp.escape(RailsPulse::VERSION)}/, @output.string)
+    %w[Database: Schema: Migrations: Routes: Initializer: Tracking: Dashboard: Summaries:].each do |label|
+      assert_includes @output.string, label
+    end
+  end
+
+  test "returns true and says OK when nothing needs action" do
+    assume_clean_install
+
+    assert report
+    assert_includes @output.string, "Schema:     up to date"
+    assert_includes @output.string, "Migrations: none pending"
+    assert_includes @output.string, "OK — nothing to do."
+    assert_not_includes @output.string, "Action needed"
+  end
+
+  # Action Tests
+
+  test "schema drift is reported with the upgrade commands and fails the report" do
+    assume_clean_install
+    RailsPulse::SchemaCheck.stubs(:expected_schema).returns("rails_pulse_routes" => { "http_methods" => {}, "ghost" => {} })
+
+    assert_not report
+    assert_includes @output.string, "Schema:     BEHIND this gem version"
+    assert_includes @output.string, "rails_pulse_routes: missing ghost"
+    assert_includes @output.string, "Routes:     (skipped — schema is behind)"
+    assert_match(/Action needed:.*rails generate rails_pulse:upgrade/m, @output.string)
+  end
+
+  test "migration files present but not run are listed" do
+    assume_clean_install
+    RailsPulse::Tasks::StatusReporter.any_instance.stubs(:pending_migrations).returns([ "20990101000000_future_change.rb" ])
+
+    assert_not report
+    assert_includes @output.string, "1 migration file(s) present but not run"
+    assert_includes @output.string, "20990101000000_future_change.rb"
+    assert_match(/Run pending migrations: rails db:migrate/, @output.string)
+  end
+
+  test "gem migrations not yet copied into the app point at the upgrade generator" do
+    assume_clean_install
+    RailsPulse::Tasks::StatusReporter.any_instance.stubs(:gem_migrations_not_in_host).returns([ "20990101000000_new_feature.rb" ])
+
+    assert_not report
+    assert_includes @output.string, "not yet copied into this app"
+    assert_match(/Copy this version's migrations: rails generate rails_pulse:upgrade/, @output.string)
+  end
+
+  test "an outstanding route backfill is reported" do
+    assume_clean_install
+    RailsPulse::Route.stubs(:needs_action_backfill?).returns(true)
+
+    assert_not report
+    assert_includes @output.string, "actions NOT backfilled"
+    assert_match(/rails rails_pulse:migrate_routes/, @output.string)
+  end
+
+  test "initializer settings this version added but the host does not mention are listed" do
+    assume_clean_install
+    RailsPulse::Installers::ConfigUpdater.stubs(:missing).returns(keys: %w[authorize], hash_keys: %w[rails_pulse_deployments])
+
+    assert_not report
+    assert_includes @output.string, "2 setting(s) from this version not mentioned: authorize, rails_pulse_deployments"
+    assert_match(/Append the new settings to the initializer/, @output.string)
+  end
+
+  test "a missing initializer points at the install generator" do
+    assume_clean_install
+    Rails.stubs(:root).returns(Pathname.new(Dir.mktmpdir))
+
+    assert_not report
+    assert_includes @output.string, "config/initializers/rails_pulse.rb not found"
+    assert_match(/rails generate rails_pulse:install/, @output.string)
+  end
+
+  # Edge Cases
+
+  test "stale summaries are called out but are not an action" do
+    assume_clean_install
+    RailsPulse::Summary.stubs(:maximum).returns(3.hours.ago)
+
+    assert report
+    assert_match(/Summaries:  last generated 3h ago — stale/, @output.string)
+  end
+
+  test "no summaries at all is called out but is not an action" do
+    assume_clean_install
+    RailsPulse::Summary.stubs(:maximum).returns(nil)
+
+    assert report
+    assert_includes @output.string, "Summaries:  none generated yet"
+  end
+
+  private
+
+  def report
+    RailsPulse::Tasks::StatusReporter.report(output: @output)
+  end
+
+  # The dummy app is not a host app: it has no config/initializers/rails_pulse.rb
+  # at Rails.root's expected place in every worker, its migrations live in
+  # test/dummy/db/migrate, and fixtures may leave routes without actions.
+  # Pin those so each test controls exactly one variable.
+  def assume_clean_install
+    RailsPulse::Tasks::StatusReporter.any_instance.stubs(:gem_migrations_not_in_host).returns([])
+    RailsPulse::Tasks::StatusReporter.any_instance.stubs(:pending_migrations).returns([])
+    RailsPulse::Route.stubs(:needs_action_backfill?).returns(false)
+    RailsPulse::RouteIndexes.stubs(:exists?).returns(true)
+    RailsPulse::Installers::ConfigUpdater.stubs(:missing).returns(keys: [], hash_keys: [])
+    RailsPulse::Summary.stubs(:maximum).returns(5.minutes.ago)
+  end
+end

--- a/test/lib/rails_pulse/tasks/status_reporter_test.rb
+++ b/test/lib/rails_pulse/tasks/status_reporter_test.rb
@@ -39,7 +39,7 @@ class RailsPulse::Tasks::StatusReporterTest < ActiveSupport::TestCase
 
   test "schema drift is reported with the upgrade commands and fails the report" do
     assume_clean_install
-    RailsPulse::SchemaCheck.stubs(:expected_schema).returns("rails_pulse_routes" => { "http_methods" => {}, "ghost" => {} })
+    RailsPulse::SchemaCheck.stubs(:expected_schema).returns("rails_pulse_routes" => %w[http_methods ghost])
 
     assert_not report
     assert_includes @output.string, "Schema:     BEHIND this gem version"

--- a/test/lib/tasks/rails_pulse_tasks_test.rb
+++ b/test/lib/tasks/rails_pulse_tasks_test.rb
@@ -40,6 +40,36 @@ class RailsPulseTasksTest < ActiveSupport::TestCase
     output.string
   end
 
+  # rails_pulse:status tests
+
+  test "status task is registered" do
+    assert Rake::Task.task_defined?("rails_pulse:status")
+  end
+
+  test "status task prints the report and exits non-zero when action is needed" do
+    RailsPulse::Tasks::StatusReporter.stubs(:report).returns(false)
+
+    exit_status = nil
+    reenable_and_capture("rails_pulse:status") do
+      begin
+        Rake::Task["rails_pulse:status"].invoke
+      rescue SystemExit => e
+        exit_status = e.status
+        raise
+      end
+    end
+
+    assert_equal 1, exit_status
+  end
+
+  test "status task exits normally when nothing needs action" do
+    RailsPulse::Tasks::StatusReporter.stubs(:report).returns(true)
+
+    assert_nothing_raised do
+      reenable_and_capture("rails_pulse:status") { Rake::Task["rails_pulse:status"].invoke }
+    end
+  end
+
   # rails_pulse:cleanup tests
 
   test "cleanup task outputs disabled message and exits when archiving_enabled is false" do


### PR DESCRIPTION
mise ~/.config/mise/config.toml tools: gh@2.99.0
## Summary

Adds `rails rails_pulse:status`: one shell command that says where an install stands, so the state an upgrade leaves behind — migrations copied but not run, schema behind the gem, route backfill outstanding, initializer missing this version's settings — is visible without opening the dashboard or guessing.

The motivating case: a host had every 0.4 migration file committed, but production had not run them, and nothing short of connecting to the database revealed that until the next deploy would have crashed.

**Stacked on #236** (`feat/schema-drift-guard`), which provides `RailsPulse::SchemaCheck`; the diff here is only the last commit.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- **`RailsPulse::Tasks::StatusReporter`** (`lib/rails_pulse/tasks/status_reporter.rb`), following the `CleanupTaskRunner` / `CleanupStatsReporter` shape (`report(output:)`, returns a boolean). Sections, all against the Pulse connection (separate database respected):
  - Database adapter and config name
  - Schema: current for this gem, or the missing tables/columns (via `SchemaCheck`)
  - Migrations: gem migrations not yet copied into `db/migrate` / `db/rails_pulse_migrate`, and migration files present but not applied
  - Routes: `Route.needs_action_backfill?` and whether the unrecognised-path unique index exists (`RouteIndexes.exists?`)
  - Initializer: settings from this version's template that the host file does not mention
  - Tracking / dashboard configuration summary (enabled, jobs, exceptions, async, `mount_dashboard`, how authentication is configured)
  - Summaries: last generated, flagged stale after 2 hours (informational only)
  - Closing "Action needed" list, or "OK — nothing to do."
- **`rake rails_pulse:status`** exits 1 when anything needs action, so it can gate a deploy.
- **`RailsPulse::Installers::ConfigUpdater.missing`** — the read-only counterpart of `update`, returning what `update` would add without writing. Backs the initializer check.
- `README.md` (Upgrading), `docs/database_setup.md` and `CHANGELOG.md` updated.

### Test Results

- [x] All existing tests pass (`DB=sqlite3 rake test`, including `test_migrations`)
- [x] New tests added for new functionality — `status_reporter_test.rb` covers every section, the OK path, and one action per probe (schema drift, unrun migrations, uncopied gem migrations, route backfill, missing initializer settings, missing initializer file), plus the non-action summary states; rake task registration and exit code; `ConfigUpdater.missing`
- [x] Manual testing completed — run against the dummy app
- [ ] Tested across multiple databases — SQLite locally; `migration_context` and `indexes` are adapter-neutral
- [ ] Tested across multiple Rails versions — 8.1 locally. `connection_pool.migration_context` is 7.2+, which matches the Appraisals matrix

## Breaking Changes

- [x] No breaking changes

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Comments added for complex logic
- [x] Documentation updated (if applicable)
- [x] No new warnings or errors introduced
- [x] Tests added/updated and passing
- [x] Changes work with all supported databases
- [x] Changes work with all supported Rails versions
- [x] Asset changes compiled and included (if applicable) — none

## Additional Notes

Exiting 1 on "action needed" is a deliberate choice so the task is useful in release scripts; if you'd rather it always exit 0 and leave gating to the caller, that is a one-line change in the rake task.
