### PR TITLE
Make status bar badges clickable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Dashboard status bar badges are now all clickable.** Routes, Queries, and Jobs badges link to their respective pages, matching Exceptions and Storage.
 - **Standalone auth notice logged once per process.** The "standalone dashboard ignores config.authentication_method / config.authorize" notice kept its once-only flag on each controller class, so it repeated for every engine controller a visitor reached. The flag now lives on `RailsPulse::Standalone` and the notice is logged once per process.
 
 ## [0.4.0.pre.4] - 2026-09-07

--- a/app/views/rails_pulse/dashboard/index.html.erb
+++ b/app/views/rails_pulse/dashboard/index.html.erb
@@ -4,16 +4,19 @@
       <%= render "rails_pulse/dashboard/health_badge",
       name: "Routes",
       health: @health_summary[:routes],
-      critical_label: "critical" %>
+      critical_label: "critical",
+      link_url: routes_path %>
       <%= render "rails_pulse/dashboard/health_badge",
       name: "Queries",
       health: @health_summary[:queries],
-      critical_label: "critical" %>
+      critical_label: "critical",
+      link_url: queries_path %>
       <% if @health_summary[:jobs] %>
         <%= render "rails_pulse/dashboard/health_badge",
         name: "Jobs",
         health: @health_summary[:jobs],
-        critical_label: "failing" %>
+        critical_label: "failing",
+        link_url: jobs_path %>
       <% end %>
       <%# Nil when exception tracking is off, or when the tables have not been
           migrated yet — which is also when exceptions_path does not exist. %>


### PR DESCRIPTION
## Summary
- Routes, Queries, and Jobs badges in the dashboard status bar now link to their pages, matching Exceptions and Storage.

## Test plan
- [x] Dashboard controller tests pass