### PR TITLE
Make routes 'filter by action' a select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Routes filter by action is now a dropdown.** Replaced the free-text "Filter by action" field with a select listing the actions that actually exist, so filtering is exact instead of substring-matched.
+
 ### Fixed
 
 - **Standalone auth notice logged once per process.** The "standalone dashboard ignores config.authentication_method / config.authorize" notice kept its once-only flag on each controller class, so it repeated for every engine controller a visitor reached. The flag now lives on `RailsPulse::Standalone` and the notice is logged once per process.

--- a/app/controllers/rails_pulse/routes_controller.rb
+++ b/app/controllers/rails_pulse/routes_controller.rb
@@ -9,6 +9,7 @@ module RailsPulse
     def index
       setup_metric_cards
       setup_chart_and_table_data
+      @available_actions = Route.distinct.pluck(:controller_action).compact_blank.sort
     end
 
     def show
@@ -112,7 +113,7 @@ module RailsPulse
 
     # Request/route-name filters that Summary chart queries don't join for.
     def chart_filter_exclusions
-      %w[route_path_cont route_controller_action_cont controller_action_cont http_method_eq]
+      %w[route_path_cont route_controller_action_eq controller_action_cont http_method_eq]
     end
 
     def default_time_range_key

--- a/app/views/rails_pulse/routes/index.html.erb
+++ b/app/views/rails_pulse/routes/index.html.erb
@@ -28,10 +28,10 @@
                           placeholder: "Filter by path",
                           autocomplete: "off",
                           class: "input" %>
-        <%= form.search_field :route_controller_action_cont,
-                          placeholder: "Filter by action",
-                          autocomplete: "off",
-                          class: "input" %>
+        <%= form.select :route_controller_action_eq,
+                    options_for_select([["All actions", ""]] + @available_actions.map { |a| [a, a] }, @ransack_query.route_controller_action_eq),
+                    {},
+                    { class: "input" } %>
         <%= form.select :avg_duration,
                     duration_options(:route),
                     { selected: @selected_response_range },


### PR DESCRIPTION
## Summary
- Replaced the free-text "Filter by action" field on the routes index with a select listing existing actions.

## Test plan
- [x] Routes controller tests pass