### PR TITLE
Fall back to archived summaries on Route show page past retention

### DIFF
--- a/app/controllers/rails_pulse/routes_controller.rb
+++ b/app/controllers/rails_pulse/routes_controller.rb
@@ -14,6 +14,7 @@ module RailsPulse
     def show
       setup_metric_cards
       setup_chart_and_table_data
+      setup_archived_summary_data
     end
 
     private
@@ -124,6 +125,36 @@ module RailsPulse
 
     def set_route
       @route = Route.find(params[:id])
+    end
+
+    # Raw Request rows get purged by CleanupService after full_retention_period.
+    # For any part of the selected window older than that cutoff, fall back to
+    # pre-aggregated Summary rows (which CleanupService never deletes for
+    # day/week/month periods) so the table isn't just blank for old ranges.
+    def setup_archived_summary_data
+      cutoff = retention_cutoff
+      window_start = @page_timings&.table_start_time
+
+      if cutoff && window_start && Time.at(window_start) < cutoff
+        scope = Summary.for_routes
+          .where(summarizable_id: @route.id)
+          .where(period_type: period_type)
+          .where("period_start < ?", cutoff)
+
+        if @page_timings&.table_end_time
+          scope = scope.where("period_start < ?", Time.at(@page_timings.table_end_time))
+        end
+
+        @archived_summary_data = scope.order(period_start: :desc).limit(100)
+      else
+        @archived_summary_data = Summary.none
+      end
+    end
+
+    def retention_cutoff
+      config = RailsPulse.configuration rescue nil
+      period = config&.full_retention_period
+      period ? period.ago : nil
     end
 
     def ordering_by_computed_column?

--- a/app/controllers/rails_pulse/routes_controller.rb
+++ b/app/controllers/rails_pulse/routes_controller.rb
@@ -127,6 +127,8 @@ module RailsPulse
       @route = Route.find(params[:id])
     end
 
+    ARCHIVED_SUMMARY_PAGE_LIMIT = 20
+
     # Raw Request rows get purged by CleanupService after full_retention_period.
     # For any part of the selected window older than that cutoff, fall back to
     # pre-aggregated Summary rows (which CleanupService never deletes for
@@ -135,7 +137,7 @@ module RailsPulse
       cutoff = retention_cutoff
       window_start = @page_timings&.table_start_time
 
-      if cutoff && window_start && Time.at(window_start) < cutoff
+      scope = if cutoff && window_start && Time.at(window_start) < cutoff
         scope = Summary.for_routes
           .where(summarizable_id: @route.id)
           .where(period_type: period_type)
@@ -145,10 +147,23 @@ module RailsPulse
           scope = scope.where("period_start < ?", Time.at(@page_timings.table_end_time))
         end
 
-        @archived_summary_data = scope.order(period_start: :desc).limit(100)
+        scope.order(period_start: :desc)
       else
-        @archived_summary_data = Summary.none
+        Summary.none
       end
+
+      @archived_pagination, @archived_summary_data =
+        paginate_archived(scope, limit: ARCHIVED_SUMMARY_PAGE_LIMIT)
+    end
+
+    # Mirrors PaginationConcern#paginate but keys off its own `archived_page`
+    # param so the archived table's pagination doesn't fight over the same
+    # `page`/`limit` params as the live requests table above it on the page.
+    def paginate_archived(collection, limit:)
+      page = [ params[:archived_page].to_i, 1 ].max
+      paginator = RailsPulse::Paginator.new(count: collection.count(:all), page: page, limit: limit)
+      records = collection.offset((paginator.page - 1) * limit).limit(limit)
+      [ paginator, records ]
     end
 
     def retention_cutoff

--- a/app/helpers/rails_pulse/application_helper.rb
+++ b/app/helpers/rails_pulse/application_helper.rb
@@ -33,7 +33,7 @@ module RailsPulse
     end
 
     def archived_page_url(page_number)
-      url_for(request.query_parameters.merge(archived_page: page_number))
+      url_for(request.query_parameters.merge(archived_page: page_number, anchor: "archived-data"))
     end
   end
 end

--- a/app/helpers/rails_pulse/application_helper.rb
+++ b/app/helpers/rails_pulse/application_helper.rb
@@ -31,5 +31,9 @@ module RailsPulse
     def page_url(page_number)
       url_for(request.query_parameters.merge(page: page_number))
     end
+
+    def archived_page_url(page_number)
+      url_for(request.query_parameters.merge(archived_page: page_number))
+    end
   end
 end

--- a/app/views/rails_pulse/routes/_archived_summary_table.html.erb
+++ b/app/views/rails_pulse/routes/_archived_summary_table.html.erb
@@ -42,3 +42,5 @@
     <% end %>
   </tbody>
 </table>
+
+<%= render "rails_pulse/routes/archived_table_pagination" %>

--- a/app/views/rails_pulse/routes/_archived_summary_table.html.erb
+++ b/app/views/rails_pulse/routes/_archived_summary_table.html.erb
@@ -1,9 +1,9 @@
 <% columns = [
-  { field: :period_start, label: 'Time Period', class: 'w-auto' },
-  { field: :count, label: 'Requests', class: 'w-32' },
-  { field: :avg_duration, label: 'Avg Duration', class: 'w-32' },
-  { field: :min_duration, label: 'Min Duration', class: 'w-32' },
-  { field: :max_duration, label: 'Max Duration', class: 'w-32' }
+  { field: :period_start, label: 'Time Period', class: 'w-auto', sortable: false },
+  { field: :count, label: 'Requests', class: 'w-32', sortable: false },
+  { field: :avg_duration, label: 'Avg Duration', class: 'w-32', sortable: false },
+  { field: :min_duration, label: 'Min Duration', class: 'w-32', sortable: false },
+  { field: :max_duration, label: 'Max Duration', class: 'w-32', sortable: false }
 ] %>
 
 <table class="table mbs-4">

--- a/app/views/rails_pulse/routes/_archived_summary_table.html.erb
+++ b/app/views/rails_pulse/routes/_archived_summary_table.html.erb
@@ -1,0 +1,44 @@
+<% columns = [
+  { field: :period_start, label: 'Time Period', class: 'w-auto' },
+  { field: :count, label: 'Requests', class: 'w-32' },
+  { field: :avg_duration, label: 'Avg Duration', class: 'w-32' },
+  { field: :min_duration, label: 'Min Duration', class: 'w-32' },
+  { field: :max_duration, label: 'Max Duration', class: 'w-32' }
+] %>
+
+<table class="table mbs-4">
+  <%= render "rails_pulse/components/table_head", columns: columns %>
+
+  <tbody>
+    <% @archived_summary_data.each do |summary| %>
+      <%
+        avg_duration_ms = summary.avg_duration&.round(2) || 0
+        performance_class = case avg_duration_ms
+        when 0..100 then "text-green-600"
+        when 100..300 then "text-yellow-600"
+        when 300..1000 then "text-orange-600"
+        else "text-red-600"
+        end
+      %>
+      <tr>
+        <td class="whitespace-nowrap">
+          <%= human_readable_summary_period(summary) %>
+        </td>
+        <td class="whitespace-nowrap text-center">
+          <span class="font-medium"><%= summary.count %></span>
+        </td>
+        <td class="whitespace-nowrap">
+          <span class="<%= performance_class %> font-medium">
+            <%= avg_duration_ms %> ms
+          </span>
+        </td>
+        <td class="whitespace-nowrap text-center">
+          <%= summary.min_duration&.round(2) || 0 %> ms
+        </td>
+        <td class="whitespace-nowrap text-center">
+          <%= summary.max_duration&.round(2) || 0 %> ms
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/rails_pulse/routes/_archived_table_pagination.html.erb
+++ b/app/views/rails_pulse/routes/_archived_table_pagination.html.erb
@@ -1,0 +1,28 @@
+<div class="flex items-center mbs-4">
+  <div class="text-sm text-subtle show@md">Total of <%= @archived_pagination.count %> archived period(s).</div>
+
+  <div class="flex items-center mis-auto justify-end" style="column-gap: 1rem">
+    <div class="text-sm font-medium"><%= "Page #{@archived_pagination.page} of #{@archived_pagination.last}" %></div>
+
+    <nav class="flex items-center gap shrink-0" style="--btn-padding: .5rem;" aria-label="Archived data pagination">
+      <% prev_page = @archived_pagination.previous %>
+      <% next_page = @archived_pagination.next %>
+      <%= link_to archived_page_url(1), class: "btn", aria: { disabled: prev_page.nil? }.compact_blank do %>
+        <%= rails_pulse_icon 'chevrons-left', width: '16', height: '16' %>
+        <span class="sr-only">Go to first page</span>
+      <% end %>
+      <%= link_to archived_page_url(prev_page || @archived_pagination.page), class: "btn", aria: { disabled: prev_page.nil? }.compact_blank do %>
+        <%= rails_pulse_icon 'chevron-left', width: '16', height: '16' %>
+        <span class="sr-only">Go to previous page</span>
+      <% end %>
+      <%= link_to archived_page_url(next_page || @archived_pagination.page), class: "btn", aria: { disabled: next_page.nil? }.compact_blank do %>
+        <%= rails_pulse_icon 'chevron-right', width: '16', height: '16' %>
+        <span class="sr-only">Go to next page</span>
+      <% end %>
+      <%= link_to archived_page_url(@archived_pagination.last), class: "btn", aria: { disabled: next_page.nil? }.compact_blank do %>
+        <%= rails_pulse_icon 'chevrons-right', width: '16', height: '16' %>
+        <span class="sr-only">Go to last page</span>
+      <% end %>
+    </nav>
+  </div>
+</div>

--- a/app/views/rails_pulse/routes/show.html.erb
+++ b/app/views/rails_pulse/routes/show.html.erb
@@ -53,7 +53,7 @@
           <% end %>
 
           <% if has_archived_summaries %>
-            <h3 class="text-sm font-semibold text-subtle mbs-8 mbe-2">
+            <h3 id="archived-data" class="text-sm font-semibold text-subtle mbs-8 mbe-2">
               Archived data (older than the retention window — aggregated by period)
             </h3>
             <%= render 'rails_pulse/routes/archived_summary_table' %>

--- a/app/views/rails_pulse/routes/show.html.erb
+++ b/app/views/rails_pulse/routes/show.html.erb
@@ -45,9 +45,21 @@
 
       <div data-controller="rails-pulse--table-sort">
         <div id="index_table" data-rails-pulse--index-target="indexTable" data-rails-pulse--table-sort-target="tableFrame">
-          <% if @table_data && @table_data.any? %>
+          <% has_requests = @table_data && @table_data.any? %>
+          <% has_archived_summaries = @archived_summary_data && @archived_summary_data.any? %>
+
+          <% if has_requests %>
             <%= render 'rails_pulse/routes/requests_table' %>
-          <% else %>
+          <% end %>
+
+          <% if has_archived_summaries %>
+            <h3 class="text-sm font-semibold text-subtle mbs-8 mbe-2">
+              Archived data (older than the retention window — aggregated by period)
+            </h3>
+            <%= render 'rails_pulse/routes/archived_summary_table' %>
+          <% end %>
+
+          <% unless has_requests || has_archived_summaries %>
             <%= render 'rails_pulse/components/empty_state',
                 title: 'No route requests found for the selected filters.',
                 description: 'Try adjusting your time range or filters to see results.' %>


### PR DESCRIPTION
## Summary
- Raw `Request` rows get purged by `CleanupService` after `full_retention_period`, but day/week/month `Summary` rows for a route are never deleted — so the Route show page's requests table went blank for any time range reaching past that cutoff, even though the chart/metric cards (Summary-driven) still had data.
- When the selected window extends past the retention cutoff, render aggregated `Summary` rows for the older portion in a separate "Archived data" section below the live per-request table, instead of showing nothing.
- The archived section has its own pagination (`archived_page` query param, independent of the live table's `page`/`limit`) and its column headers are non-sortable (they previously reused the shared sortable `table_head` partial, which wired sort links to the live requests ransack query and showed a misleading, non-functional sort indicator).
- Pagination links carry a `#archived-data` anchor so paging doesn't reset scroll to the top of the page.

## Test plan
- [x] Visit a route's show page with a time range that extends past `full_retention_period` (e.g. `?q[period_start_range]=last_30_days` with a short retention window) and confirm archived summary rows render below the live requests table.
- [ ] Confirm archived table pagination (first/prev/next/last) pages independently of the live requests table's pagination.
- [x] Confirm archived table column headers are plain labels, not sort links, and clicking them does not alter the live requests table's sort order.
- [x] Confirm a route/time range with no archived data still shows the existing empty state correctly.