### PR TITLE
Honor config.logger in RailsPulse.logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`config.logger` is now honored.** `RailsPulse.logger` previously ignored a custom logger set in the initializer and always wrote to the tagged `Rails.logger`; the configured logger now receives all Rails Pulse log output. (#244)
 - **Dashboard status bar badges are now all clickable.** Routes, Queries, and Jobs badges link to their respective pages, matching Exceptions and Storage.
 - **Standalone auth notice logged once per process.** The "standalone dashboard ignores config.authentication_method / config.authorize" notice kept its once-only flag on each controller class, so it repeated for every engine controller a visitor reached. The flag now lives on `RailsPulse::Standalone` and the notice is logged once per process.
 

--- a/lib/rails_pulse.rb
+++ b/lib/rails_pulse.rb
@@ -33,6 +33,9 @@ module RailsPulse
     end
 
     def logger
+      configured = configuration&.logger
+      return configured if configured
+
       if defined?(Rails) && Rails.respond_to?(:logger) && Rails.logger
         @logger ||= ActiveSupport::TaggedLogging.new(Rails.logger).tagged("RailsPulse")
       else

--- a/test/rails_pulse_test.rb
+++ b/test/rails_pulse_test.rb
@@ -146,6 +146,44 @@ class RailsPulseTest < ActiveSupport::TestCase
     assert_same RailsPulse.logger, RailsPulse.logger
   end
 
+  test "logger delivers messages to the configured logger instead of Rails.logger" do
+    original = Rails.logger
+    rails_output = StringIO.new
+    custom_output = StringIO.new
+    Rails.logger = Logger.new(rails_output)
+    RailsPulse.instance_variable_set(:@logger, nil)
+    RailsPulse.configuration.logger = Logger.new(custom_output)
+
+    RailsPulse.logger.warn("configured logger probe")
+
+    assert_includes custom_output.string, "configured logger probe"
+    assert_not_includes rails_output.string, "configured logger probe"
+  ensure
+    Rails.logger = original
+    RailsPulse.instance_variable_set(:@logger, nil)
+  end
+
+  test "logger honors a logger configured after the default logger was already used" do
+    original = Rails.logger
+    rails_output = StringIO.new
+    custom_output = StringIO.new
+    Rails.logger = Logger.new(rails_output)
+    RailsPulse.instance_variable_set(:@logger, nil)
+
+    RailsPulse.logger.warn("before configuration")
+
+    assert_includes rails_output.string, "before configuration"
+
+    RailsPulse.configuration.logger = Logger.new(custom_output)
+    RailsPulse.logger.warn("after configuration")
+
+    assert_includes custom_output.string, "after configuration"
+    assert_not_includes rails_output.string, "after configuration"
+  ensure
+    Rails.logger = original
+    RailsPulse.instance_variable_set(:@logger, nil)
+  end
+
   # connects_to
 
   test "connects_to returns nil when configuration has no connects_to" do


### PR DESCRIPTION
Fixes #244

## Problem

`RailsPulse.configuration.logger` accepted and retained a custom logger, but `RailsPulse.logger` never consulted it. All Rails Pulse log output went to a tagged `Rails.logger` (or stdout when no Rails logger was present), so apps could not redirect or silence Rails Pulse logging through the documented option.

## Fix

`RailsPulse.logger` now returns `configuration.logger` when one is set, before falling through to the existing tagged `Rails.logger` path and the non-memoized stdout fallback. The configured logger is returned as-is and is not memoized, so:

- setting it after the default logger has already been used takes effect immediately
- a user-supplied logger that does not support `tagged` still works

## Tests

Two regression tests in `test/rails_pulse_test.rb` assert actual message delivery to the configured logger and that `Rails.logger` does not receive it. One covers the case where the logger is configured after the default was already memoized.

- Full SQLite suite passes (3,434 tests).
- The reproduction script from the issue, run verbatim, now reports `custom_received_message: true` and `rails_received_message: false`.